### PR TITLE
Support Priority by Severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0
+
+* Support Priority by Severity
+    * high -> critical
+    * medium -> warning
+    * low -> information
+* Severity is added as label to result metrics
+* Severity is added in Policy Reporter UI tables
+* Add "Critical" as new Priority to differ between Errored Policies and Failed priorities with High Severity
+* Use "Warning" as new default Priority instead of Error which should now used for Policies in Error Status
+
 ## 0.22.0
 
 * New Target Policy Reporter UI

--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: monitoring
   repository: ""
-  version: 0.3.0
+  version: 1.0.0
 - name: ui
   repository: ""
-  version: 0.5.0
-digest: sha256:15549ff4f94ac43da2be66e8d332bfa2be05d4c13bc0820eb908a6341c1e32c0
-generated: "2021-03-21T18:20:41.565564+01:00"
+  version: 1.0.0
+digest: sha256:fb651a8155fa0d875e5cf260b34dc7bdd4b0331f93f58fa560139861d6988b02
+generated: "2021-04-02T11:55:33.612666+02:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,15 +5,15 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 0.22.0
-appVersion: 0.14.0
+version: 1.0.0
+appVersion: 1.0.0
 
 dependencies:
   - name: monitoring
     condition: monitoring.enabled
     repository: ""
-    version: "0.3.0"
+    version: "1.0.0"
   - name: ui
     condition: ui.enabled
     repository: ""
-    version: "0.5.0"
+    version: "1.0.0"

--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 0.3.0
+version: 1.0.0
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 0.5.0
-appVersion: 0.5.0
+version: 1.0.0
+appVersion: 0.6.0

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -7,7 +7,7 @@ log:
 image:
   repository: fjogeleit/policy-reporter-ui
   pullPolicy: IfNotPresent
-  tag: 0.5.0
+  tag: 0.6.0
 
 imagePullSecrets: []
 

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -105,7 +105,7 @@ target:
   loki:
     # loki host address
     host: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
@@ -118,7 +118,7 @@ target:
     # elasticsearch index rotation and index suffix
     # possible values: dayli, monthly, annually, none (default: dayli)
     rotation: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
@@ -126,7 +126,7 @@ target:
   slack:
     # slack app webhook address
     webhook: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
@@ -134,7 +134,7 @@ target:
   discord:
     # discord app webhook address
     webhook: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
@@ -142,7 +142,7 @@ target:
   teams:
     # teams webhook address
     webhook: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
@@ -150,7 +150,7 @@ target:
   ui:
     # teams webhook address
     host: ""
-    # minimum priority "" < info < warning < error
+    # minimum priority "" < info < warning < critical < error
     minimumPriority: "warning"
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: fjogeleit/policy-reporter
   pullPolicy: IfNotPresent
-  tag: 0.14.0
+  tag: 1.0.0
 
 imagePullSecrets: []
 

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: fjogeleit/policy-reporter
   pullPolicy: IfNotPresent
-  tag: 1.0.0
+  tag: 1.0.1
 
 imagePullSecrets: []
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -98,7 +98,7 @@ func newRunCMD() *cobra.Command {
 	cmd.PersistentFlags().IntP("apiPort", "a", 0, "http port for the optional rest api")
 
 	cmd.PersistentFlags().String("loki", "", "loki host: http://loki:3100")
-	cmd.PersistentFlags().String("loki-minimum-priority", "", "Minimum Priority to send Results to Loki (info < warning < error)")
+	cmd.PersistentFlags().String("loki-minimum-priority", "", "Minimum Priority to send Results to Loki (info < warning < critical < error)")
 	cmd.PersistentFlags().Bool("loki-skip-existing-on-startup", false, "Skip Results created before PolicyReporter started. Prevent duplicated sending after new deployment")
 
 	flag.Parse()

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -74,7 +74,7 @@ func newSendCMD() *cobra.Command {
 	cmd.PersistentFlags().StringP("config", "c", "", "target configuration file")
 
 	cmd.PersistentFlags().String("loki", "", "loki host: http://loki:3100")
-	cmd.PersistentFlags().String("loki-minimum-priority", "", "Minimum Priority to send Results to Loki (info < warning < error)")
+	cmd.PersistentFlags().String("loki-minimum-priority", "", "Minimum Priority to send Results to Loki (info < warning < critical < error)")
 
 	flag.Parse()
 

--- a/pkg/kubernetes/cluster_policy_report_client_test.go
+++ b/pkg/kubernetes/cluster_policy_report_client_test.go
@@ -346,7 +346,7 @@ func Test_WatchModifiedEvent(t *testing.T) {
 				"policy":   "required-label",
 				"rule":     "app-label-required",
 				"category": "test",
-				"severity": "low",
+				"severity": "high",
 				"resources": []interface{}{
 					map[string]interface{}{
 						"apiVersion": "v1",

--- a/pkg/kubernetes/config_map_adapter_test.go
+++ b/pkg/kubernetes/config_map_adapter_test.go
@@ -24,7 +24,7 @@ var configMap = &v1.ConfigMap{
 		Name: "policy-reporter-priorities",
 	},
 	Data: map[string]string{
-		"default": "warning",
+		"default": "critical",
 	},
 }
 
@@ -42,7 +42,7 @@ func Test_GetConfigMap(t *testing.T) {
 	if cm.Name != "policy-reporter-priorities" {
 		t.Error("Unexpted ConfigMapReturned")
 	}
-	if priority, ok := cm.Data["default"]; !ok || priority != "warning" {
+	if priority, ok := cm.Data["default"]; !ok || priority != "critical" {
 		t.Error("Unexpted default priority")
 	}
 }
@@ -64,7 +64,7 @@ func Test_WatchConfigMap(t *testing.T) {
 		if cm.Name != "policy-reporter-priorities" {
 			t.Error("Unexpted ConfigMapReturned")
 		}
-		if priority, ok := cm.Data["default"]; !ok || priority != "warning" {
+		if priority, ok := cm.Data["default"]; !ok || priority != "critical" {
 			t.Error("Unexpted default priority")
 		}
 	})

--- a/pkg/kubernetes/mapper_test.go
+++ b/pkg/kubernetes/mapper_test.go
@@ -34,7 +34,7 @@ var policyMap = map[string]interface{}{
 			"policy":   "required-label",
 			"rule":     "app-label-required",
 			"category": "test",
-			"severity": "low",
+			"severity": "high",
 			"resources": []interface{}{
 				map[string]interface{}{
 					"apiVersion": "v1",
@@ -83,7 +83,7 @@ var clusterPolicyMap = map[string]interface{}{
 			"policy":   "required-label",
 			"rule":     "app-label-required",
 			"category": "test",
-			"severity": "low",
+			"severity": "high",
 			"resources": []interface{}{
 				map[string]interface{}{
 					"apiVersion": "v1",
@@ -145,8 +145,8 @@ func Test_MapPolicyReport(t *testing.T) {
 	if result1.Status != report.Fail {
 		t.Errorf("Expected Message '%s' (acutal %s)", report.Fail, result1.Status)
 	}
-	if result1.Priority != report.ErrorPriority {
-		t.Errorf("Expected Priority '%d' (acutal %d)", report.ErrorPriority, result1.Priority)
+	if result1.Priority != report.CriticalPriority {
+		t.Errorf("Expected Priority '%d' (acutal %d)", report.CriticalPriority, result1.Priority)
 	}
 	if !result1.Scored {
 		t.Errorf("Expected Scored to be true")
@@ -160,8 +160,8 @@ func Test_MapPolicyReport(t *testing.T) {
 	if result1.Category != "test" {
 		t.Errorf("Expected Category 'test' (acutal %s)", result1.Category)
 	}
-	if result1.Severity != report.Low {
-		t.Errorf("Expected Severity '%s' (acutal %s)", report.Low, result1.Severity)
+	if result1.Severity != report.High {
+		t.Errorf("Expected Severity '%s' (acutal %s)", report.High, result1.Severity)
 	}
 
 	resource := result1.Resources[0]
@@ -290,10 +290,10 @@ func Test_PriorityMap(t *testing.T) {
 
 		preport := mapper.MapPolicyReport(policyMap)
 
-		result1 := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+		result := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
 
-		if result1.Priority != report.DebugPriority {
-			t.Errorf("Expected Policy '%d' (acutal %d)", report.DebugPriority, result1.Priority)
+		if result.Priority != report.DebugPriority {
+			t.Errorf("Expected Policy '%d' (acutal %d)", report.DebugPriority, result.Priority)
 		}
 	})
 
@@ -302,10 +302,10 @@ func Test_PriorityMap(t *testing.T) {
 
 		preport := mapper.MapPolicyReport(policyMap)
 
-		result1 := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+		result := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
 
-		if result1.Priority != report.DebugPriority {
-			t.Errorf("Expected Policy '%d' (acutal %d)", report.DebugPriority, result1.Priority)
+		if result.Priority != report.DebugPriority {
+			t.Errorf("Expected Policy '%d' (acutal %d)", report.DebugPriority, result.Priority)
 		}
 	})
 
@@ -314,10 +314,10 @@ func Test_PriorityMap(t *testing.T) {
 
 		preport := mapper.MapPolicyReport(policyMap)
 
-		result1 := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+		result := preport.Results["priority-test____fail"]
 
-		if result1.Priority != report.WarningPriority {
-			t.Errorf("Expected Policy '%d' (acutal %d)", report.WarningPriority, result1.Priority)
+		if result.Priority != report.WarningPriority {
+			t.Errorf("Expected Policy '%d' (acutal %d)", report.WarningPriority, result.Priority)
 		}
 	})
 }
@@ -328,17 +328,17 @@ func Test_PriorityFetch(t *testing.T) {
 	mapper := kubernetes.NewMapper(make(map[string]string), kubernetes.NewConfigMapAdapter(cmAPI))
 
 	preport1 := mapper.MapPolicyReport(policyMap)
-	result1 := preport1.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+	result1 := preport1.Results["priority-test____fail"]
 
-	if result1.Priority != report.ErrorPriority {
-		t.Errorf("Default Priority should be Error")
+	if result1.Priority != report.WarningPriority {
+		t.Errorf("Default Priority should be Warning")
 	}
 
 	mapper.FetchPriorities(context.Background())
 	preport2 := mapper.MapPolicyReport(policyMap)
-	result2 := preport2.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
-	if result2.Priority != report.WarningPriority {
-		t.Errorf("Default Priority should be Warning after ConigMap fetch")
+	result2 := preport2.Results["priority-test____fail"]
+	if result2.Priority != report.CriticalPriority {
+		t.Errorf("Default Priority should be Critical after ConigMap fetch")
 	}
 }
 
@@ -348,9 +348,9 @@ func Test_PriorityFetchError(t *testing.T) {
 
 	mapper.FetchPriorities(context.Background())
 	preport := mapper.MapPolicyReport(policyMap)
-	result := preport.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
-	if result.Priority != report.ErrorPriority {
-		t.Errorf("Fetch Error should not effect the functionality and continue using Error as default")
+	result := preport.Results["priority-test____fail"]
+	if result.Priority != report.WarningPriority {
+		t.Errorf("Fetch Error should not effect the functionality and continue using Warning as default")
 	}
 }
 
@@ -362,10 +362,10 @@ func Test_PrioritySync(t *testing.T) {
 	mapper := kubernetes.NewMapper(make(map[string]string), kubernetes.NewConfigMapAdapter(cmAPI))
 
 	preport1 := mapper.MapPolicyReport(policyMap)
-	result1 := preport1.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+	result1 := preport1.Results["priority-test____fail"]
 
-	if result1.Priority != report.ErrorPriority {
-		t.Errorf("Default Priority should be Error")
+	if result1.Priority != report.WarningPriority {
+		t.Errorf("Default Priority should be Warning")
 	}
 
 	go mapper.SyncPriorities(context.Background())
@@ -373,9 +373,9 @@ func Test_PrioritySync(t *testing.T) {
 	watcher.Add(configMap)
 
 	preport2 := mapper.MapPolicyReport(policyMap)
-	result2 := preport2.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
-	if result2.Priority != report.WarningPriority {
-		t.Errorf("Default Priority should be Warning after ConigMap add sync")
+	result2 := preport2.Results["priority-test____fail"]
+	if result2.Priority != report.CriticalPriority {
+		t.Errorf("Default Priority should be Critical after ConigMap add sync")
 	}
 
 	configMap2 := &v1.ConfigMap{
@@ -396,7 +396,7 @@ func Test_PrioritySync(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	preport3 := mapper.MapPolicyReport(policyMap)
-	result3 := preport3.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
+	result3 := preport3.Results["priority-test____fail"]
 	if result3.Priority != report.DebugPriority {
 		t.Errorf("Default Priority should be Debug after ConigMap modify sync")
 	}
@@ -406,8 +406,8 @@ func Test_PrioritySync(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	preport4 := mapper.MapPolicyReport(policyMap)
-	result4 := preport4.Results["required-label__app-label-required__fail__dfd57c50-f30c-4729-b63f-b1954d8988d1"]
-	if result4.Priority != report.ErrorPriority {
-		t.Errorf("Default Priority should be fallback to Error after ConigMap delete sync")
+	result4 := preport4.Results["priority-test____fail"]
+	if result4.Priority != report.WarningPriority {
+		t.Errorf("Default Priority should be fallback to Warning after ConigMap delete sync")
 	}
 }

--- a/pkg/kubernetes/policy_report_client_test.go
+++ b/pkg/kubernetes/policy_report_client_test.go
@@ -346,7 +346,7 @@ func Test_PolicyWatchModifiedEvent(t *testing.T) {
 				"policy":   "required-label",
 				"rule":     "app-label-required",
 				"category": "test",
-				"severity": "low",
+				"severity": "medium",
 				"resources": []interface{}{
 					map[string]interface{}{
 						"apiVersion": "v1",

--- a/pkg/metrics/cluster_policy_report.go
+++ b/pkg/metrics/cluster_policy_report.go
@@ -17,7 +17,7 @@ func CreateClusterPolicyReportMetricsCallback() report.ClusterPolicyReportCallba
 	ruleGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "cluster_policy_report_result",
 		Help: "List of all ClusterPolicyReport Results",
-	}, []string{"rule", "policy", "report", "kind", "name", "status"})
+	}, []string{"rule", "policy", "report", "kind", "name", "status", "severity"})
 
 	prometheus.Register(policyGauge)
 	prometheus.Register(ruleGauge)
@@ -29,7 +29,15 @@ func CreateClusterPolicyReportMetricsCallback() report.ClusterPolicyReportCallba
 
 			for _, rule := range report.Results {
 				res := rule.Resources[0]
-				ruleGauge.WithLabelValues(rule.Rule, rule.Policy, report.Name, res.Kind, res.Name, rule.Status).Set(1)
+				ruleGauge.WithLabelValues(
+					rule.Rule,
+					rule.Policy,
+					report.Name,
+					res.Kind,
+					res.Name,
+					rule.Status,
+					rule.Severity,
+				).Set(1)
 			}
 		case watch.Modified:
 			updateClusterPolicyGauge(policyGauge, report)
@@ -43,6 +51,7 @@ func CreateClusterPolicyReportMetricsCallback() report.ClusterPolicyReportCallba
 					res.Kind,
 					res.Name,
 					rule.Status,
+					rule.Severity,
 				)
 			}
 
@@ -56,6 +65,7 @@ func CreateClusterPolicyReportMetricsCallback() report.ClusterPolicyReportCallba
 						res.Kind,
 						res.Name,
 						rule.Status,
+						rule.Severity,
 					).
 					Set(1)
 			}
@@ -75,6 +85,7 @@ func CreateClusterPolicyReportMetricsCallback() report.ClusterPolicyReportCallba
 					res.Kind,
 					res.Name,
 					rule.Status,
+					rule.Severity,
 				)
 			}
 		}

--- a/pkg/metrics/cluster_policy_report_test.go
+++ b/pkg/metrics/cluster_policy_report_test.go
@@ -18,6 +18,7 @@ var cresult1 = report.Result{
 	Rule:     "ns-label-required",
 	Priority: report.ErrorPriority,
 	Status:   report.Fail,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{
@@ -32,9 +33,9 @@ var cresult1 = report.Result{
 
 var cresult2 = report.Result{
 	Message:  "validation error: Namespace label missing",
-	Policy:   "ns-label-env-required",
-	Rule:     "ns-label-required",
-	Priority: report.ErrorPriority,
+	Policy:   "ns-label-env-check",
+	Rule:     "ns-label-check",
+	Priority: report.WarningPriority,
 	Status:   report.Pass,
 	Category: "resources",
 	Scored:   true,
@@ -43,7 +44,7 @@ var cresult2 = report.Result{
 			APIVersion: "v1",
 			Kind:       "Namespace",
 			Name:       "stage",
-			UID:        "536ab69f-1b3c-4bd9-9ba4-274a56188419",
+			UID:        "532ab69f-1b3c-4bd9-9ba4-274a56188419",
 		},
 	},
 }
@@ -108,10 +109,10 @@ func Test_ClusterPolicyReportMetricGeneration(t *testing.T) {
 		}
 
 		metrics = results.GetMetric()
-		if err = testClusterResultMetricLabels(metrics[0], result1); err != nil {
+		if err = testClusterResultMetricLabels(metrics[0], result2); err != nil {
 			t.Error(err)
 		}
-		if err = testClusterResultMetricLabels(metrics[1], result2); err != nil {
+		if err = testClusterResultMetricLabels(metrics[1], result1); err != nil {
 			t.Error(err)
 		}
 	})
@@ -246,10 +247,17 @@ func testClusterResultMetricLabels(metric *io_prometheus_client.Metric, result r
 		return fmt.Errorf("Unexpected Rule Label Value: %s", value)
 	}
 
-	if name := *metric.Label[5].Name; name != "status" {
+	if name := *metric.Label[5].Name; name != "severity" {
 		return fmt.Errorf("Unexpected Name Label: %s", name)
 	}
-	if value := *metric.Label[5].Value; value != result.Status {
+	if value := *metric.Label[5].Value; value != result.Severity {
+		return fmt.Errorf("Unexpected Severity Label Value: %s", value)
+	}
+
+	if name := *metric.Label[6].Name; name != "status" {
+		return fmt.Errorf("Unexpected Name Label: %s", name)
+	}
+	if value := *metric.Label[6].Value; value != result.Status {
 		return fmt.Errorf("Unexpected Status Label Value: %s", value)
 	}
 

--- a/pkg/metrics/policy_report.go
+++ b/pkg/metrics/policy_report.go
@@ -17,7 +17,7 @@ func CreatePolicyReportMetricsCallback() report.PolicyReportCallback {
 	ruleGauge := promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "policy_report_result",
 		Help: "List of all PolicyReport Results",
-	}, []string{"namespace", "rule", "policy", "report", "kind", "name", "status"})
+	}, []string{"namespace", "rule", "policy", "report", "kind", "name", "status", "severity"})
 
 	prometheus.Register(policyGauge)
 	prometheus.Register(ruleGauge)
@@ -38,6 +38,7 @@ func CreatePolicyReportMetricsCallback() report.PolicyReportCallback {
 						res.Kind,
 						res.Name,
 						rule.Status,
+						rule.Severity,
 					).
 					Set(1)
 			}
@@ -54,6 +55,7 @@ func CreatePolicyReportMetricsCallback() report.PolicyReportCallback {
 					res.Kind,
 					res.Name,
 					rule.Status,
+					rule.Severity,
 				)
 			}
 
@@ -68,6 +70,7 @@ func CreatePolicyReportMetricsCallback() report.PolicyReportCallback {
 						res.Kind,
 						res.Name,
 						rule.Status,
+						rule.Severity,
 					).
 					Set(1)
 			}
@@ -89,6 +92,7 @@ func CreatePolicyReportMetricsCallback() report.PolicyReportCallback {
 					res.Kind,
 					res.Name,
 					rule.Status,
+					rule.Severity,
 				)
 			}
 		}

--- a/pkg/metrics/policy_report_test.go
+++ b/pkg/metrics/policy_report_test.go
@@ -18,6 +18,7 @@ var result1 = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.ErrorPriority,
 	Status:   report.Fail,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{
@@ -33,9 +34,9 @@ var result1 = report.Result{
 
 var result2 = report.Result{
 	Message:  "validation error: requests and limits required. Rule autogen-check-for-requests-and-limits failed at path /spec/template/spec/containers/0/resources/requests/",
-	Policy:   "require-requests-and-limits-required",
-	Rule:     "autogen-check-for-requests-and-limits",
-	Priority: report.ErrorPriority,
+	Policy:   "check-requests-and-limits-required",
+	Rule:     "check-for-requests-and-limits",
+	Priority: report.WarningPriority,
 	Status:   report.Pass,
 	Category: "resources",
 	Scored:   true,
@@ -45,7 +46,7 @@ var result2 = report.Result{
 			Kind:       "Deployment",
 			Name:       "nginx",
 			Namespace:  "test",
-			UID:        "536ab69f-1b3c-4bd9-9ba4-274a56188419",
+			UID:        "535ab69f-1b3c-4bd9-9ba4-274a56188419",
 		},
 	},
 }
@@ -111,10 +112,10 @@ func Test_PolicyReportMetricGeneration(t *testing.T) {
 		}
 
 		metrics = results.GetMetric()
-		if err = testResultMetricLabels(metrics[0], result1); err != nil {
+		if err = testResultMetricLabels(metrics[0], result2); err != nil {
 			t.Error(err)
 		}
-		if err = testResultMetricLabels(metrics[1], result2); err != nil {
+		if err = testResultMetricLabels(metrics[1], result1); err != nil {
 			t.Error(err)
 		}
 	})
@@ -262,10 +263,17 @@ func testResultMetricLabels(metric *io_prometheus_client.Metric, result report.R
 		return fmt.Errorf("Unexpected Rule Label Value: %s", value)
 	}
 
-	if name := *metric.Label[6].Name; name != "status" {
+	if name := *metric.Label[6].Name; name != "severity" {
 		return fmt.Errorf("Unexpected Name Label: %s", name)
 	}
-	if value := *metric.Label[6].Value; value != result.Status {
+	if value := *metric.Label[6].Value; value != result.Severity {
+		return fmt.Errorf("Unexpected Severity Label Value: %s", value)
+	}
+
+	if name := *metric.Label[7].Name; name != "status" {
+		return fmt.Errorf("Unexpected Name Label: %s", name)
+	}
+	if value := *metric.Label[7].Value; value != result.Status {
 		return fmt.Errorf("Unexpected Status Label Value: %s", value)
 	}
 

--- a/pkg/report/model.go
+++ b/pkg/report/model.go
@@ -38,8 +38,8 @@ const (
 	DebugPriority
 	InfoPriority
 	WarningPriority
-	ErrorPriority
 	CriticalPriority
+	ErrorPriority
 )
 
 // Priority Enum for internal Result weighting

--- a/pkg/report/model.go
+++ b/pkg/report/model.go
@@ -22,13 +22,14 @@ const (
 
 	Low    Severity = "low"
 	Medium Severity = "medium"
-	Heigh  Severity = "heigh"
+	High   Severity = "high"
 
-	defaultString = ""
-	debugString   = "debug"
-	infoString    = "info"
-	warningString = "warning"
-	errorString   = "error"
+	defaultString  = ""
+	debugString    = "debug"
+	infoString     = "info"
+	warningString  = "warning"
+	errorString    = "error"
+	criticalString = "critical"
 )
 
 // Internal Priority definitions and weighting
@@ -38,6 +39,7 @@ const (
 	InfoPriority
 	WarningPriority
 	ErrorPriority
+	CriticalPriority
 )
 
 // Priority Enum for internal Result weighting
@@ -54,6 +56,8 @@ func (p Priority) String() string {
 		return warningString
 	case ErrorPriority:
 		return errorString
+	case CriticalPriority:
+		return criticalString
 	default:
 		return defaultString
 	}
@@ -69,10 +73,10 @@ func (p Priority) MarshalJSON() ([]byte, error) {
 }
 
 // PriorityFromStatus creates a Priority based on a Status
-func PriorityFromStatus(p Status) Priority {
-	switch p {
+func PriorityFromStatus(s Status) Priority {
+	switch s {
 	case Fail:
-		return ErrorPriority
+		return CriticalPriority
 	case Error:
 		return ErrorPriority
 	case Warn:
@@ -81,6 +85,18 @@ func PriorityFromStatus(p Status) Priority {
 		return InfoPriority
 	default:
 		return DefaultPriority
+	}
+}
+
+// PriorityFromSeverity creates a Priority based on a Severity
+func PriorityFromSeverity(s Severity) Priority {
+	switch s {
+	case High:
+		return CriticalPriority
+	case Medium:
+		return WarningPriority
+	default:
+		return InfoPriority
 	}
 }
 
@@ -95,6 +111,8 @@ func NewPriority(p string) Priority {
 		return WarningPriority
 	case errorString:
 		return ErrorPriority
+	case criticalString:
+		return CriticalPriority
 	default:
 		return DefaultPriority
 	}

--- a/pkg/report/model_test.go
+++ b/pkg/report/model_test.go
@@ -15,6 +15,7 @@ var result1 = report.Result{
 	Priority: report.ErrorPriority,
 	Status:   report.Fail,
 	Category: "resources",
+	Severity: report.High,
 	Scored:   true,
 	Resources: []report.Resource{
 		{
@@ -124,25 +125,28 @@ func Test_MarshalPriority(t *testing.T) {
 
 func Test_Priorities(t *testing.T) {
 	t.Run("Priority.String", func(t *testing.T) {
-		if prio := report.Priority(0).String(); prio != "" {
+		if prio := report.Priority(report.DefaultPriority).String(); prio != "" {
 			t.Errorf("Expected Priority to be '' (actual %s)", prio)
 		}
-		if prio := report.Priority(1).String(); prio != "debug" {
+		if prio := report.Priority(report.DebugPriority).String(); prio != "debug" {
 			t.Errorf("Expected Priority to be debug (actual %s)", prio)
 		}
-		if prio := report.Priority(2).String(); prio != "info" {
+		if prio := report.Priority(report.InfoPriority).String(); prio != "info" {
 			t.Errorf("Expected Priority to be debug (actual %s)", prio)
 		}
-		if prio := report.Priority(3).String(); prio != "warning" {
+		if prio := report.Priority(report.WarningPriority).String(); prio != "warning" {
 			t.Errorf("Expected Priority to be debug (actual %s)", prio)
 		}
-		if prio := report.Priority(4).String(); prio != "error" {
+		if prio := report.Priority(report.ErrorPriority).String(); prio != "error" {
+			t.Errorf("Expected Priority to be debug (actual %s)", prio)
+		}
+		if prio := report.Priority(report.CriticalPriority).String(); prio != "critical" {
 			t.Errorf("Expected Priority to be debug (actual %s)", prio)
 		}
 	})
 	t.Run("PriorityFromStatus", func(t *testing.T) {
-		if prio := report.PriorityFromStatus(report.Fail); prio != report.ErrorPriority {
-			t.Errorf("Expected Priority to be %d (actual %d)", report.ErrorPriority, prio)
+		if prio := report.PriorityFromStatus(report.Fail); prio != report.CriticalPriority {
+			t.Errorf("Expected Priority to be %d (actual %d)", report.CriticalPriority, prio)
 		}
 		if prio := report.PriorityFromStatus(report.Error); prio != report.ErrorPriority {
 			t.Errorf("Expected Priority to be %d (actual %d)", report.ErrorPriority, prio)
@@ -157,11 +161,14 @@ func Test_Priorities(t *testing.T) {
 			t.Errorf("Expected Priority to be %d (actual %d)", report.WarningPriority, prio)
 		}
 	})
-	t.Run("PriorityFromStatus", func(t *testing.T) {
+	t.Run("NewPriority", func(t *testing.T) {
 		if prio := report.NewPriority(""); prio != report.DefaultPriority {
 			t.Errorf("Expected Priority to be %d (actual %d)", report.DefaultPriority, prio)
 		}
 		if prio := report.NewPriority("error"); prio != report.ErrorPriority {
+			t.Errorf("Expected Priority to be %d (actual %d)", report.ErrorPriority, prio)
+		}
+		if prio := report.NewPriority("critical"); prio != report.CriticalPriority {
 			t.Errorf("Expected Priority to be %d (actual %d)", report.ErrorPriority, prio)
 		}
 		if prio := report.NewPriority("warning"); prio != report.WarningPriority {
@@ -172,6 +179,17 @@ func Test_Priorities(t *testing.T) {
 		}
 		if prio := report.NewPriority("debug"); prio != report.DebugPriority {
 			t.Errorf("Expected Priority to be %d (actual %d)", report.DebugPriority, prio)
+		}
+	})
+	t.Run("PriorityFromSeverity", func(t *testing.T) {
+		if prio := report.PriorityFromSeverity(report.High); prio != report.CriticalPriority {
+			t.Errorf("Expected Priority to be %d (actual %d)", report.CriticalPriority, prio)
+		}
+		if prio := report.PriorityFromSeverity(report.Medium); prio != report.WarningPriority {
+			t.Errorf("Expected Priority to be %d (actual %d)", report.WarningPriority, prio)
+		}
+		if prio := report.PriorityFromSeverity(report.Low); prio != report.InfoPriority {
+			t.Errorf("Expected Priority to be %d (actual %d)", report.InfoPriority, prio)
 		}
 	})
 }

--- a/pkg/target/discord/discord.go
+++ b/pkg/target/discord/discord.go
@@ -32,6 +32,8 @@ type embedField struct {
 func newPayload(result report.Result) payload {
 	var color string
 	switch result.Priority {
+	case report.CriticalPriority:
+		color = "15158332"
 	case report.ErrorPriority:
 		color = "15158332"
 	case report.WarningPriority:

--- a/pkg/target/discord/discord_test.go
+++ b/pkg/target/discord/discord_test.go
@@ -14,7 +14,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{

--- a/pkg/target/elasticsearch/elasticsearch_test.go
+++ b/pkg/target/elasticsearch/elasticsearch_test.go
@@ -15,7 +15,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{

--- a/pkg/target/loki/loki_test.go
+++ b/pkg/target/loki/loki_test.go
@@ -17,7 +17,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{

--- a/pkg/target/slack/slack.go
+++ b/pkg/target/slack/slack.go
@@ -49,6 +49,9 @@ type client struct {
 }
 
 func colorFromPriority(p report.Priority) string {
+	if p == report.CriticalPriority {
+		return "#b80707"
+	}
 	if p == report.ErrorPriority {
 		return "#e20b0b"
 	}

--- a/pkg/target/slack/slack_test.go
+++ b/pkg/target/slack/slack_test.go
@@ -14,7 +14,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{
@@ -32,6 +32,30 @@ var minimalResult = report.Result{
 	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
 	Policy:   "app-label-requirement",
 	Priority: report.WarningPriority,
+	Status:   report.Fail,
+	Scored:   true,
+}
+
+var minimalErrorResult = report.Result{
+	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
+	Policy:   "app-label-requirement",
+	Priority: report.ErrorPriority,
+	Status:   report.Fail,
+	Scored:   true,
+}
+
+var minimalDebugResult = report.Result{
+	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
+	Policy:   "app-label-requirement",
+	Priority: report.DebugPriority,
+	Status:   report.Fail,
+	Scored:   true,
+}
+
+var minimalCriticalResult = report.Result{
+	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
+	Policy:   "app-label-requirement",
+	Priority: report.CriticalPriority,
 	Status:   report.Fail,
 	Scored:   true,
 }

--- a/pkg/target/teams/teams.go
+++ b/pkg/target/teams/teams.go
@@ -37,6 +37,9 @@ type payload struct {
 }
 
 func colorFromPriority(p report.Priority) string {
+	if p == report.CriticalPriority {
+		return "b80707"
+	}
 	if p == report.ErrorPriority {
 		return "e20b0b"
 	}

--- a/pkg/target/teams/teams_test.go
+++ b/pkg/target/teams/teams_test.go
@@ -15,7 +15,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{
@@ -29,10 +29,18 @@ var completeResult = report.Result{
 	},
 }
 
-var minimalResult = report.Result{
+var minimalErrorResult = report.Result{
 	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
 	Policy:   "app-label-requirement",
 	Priority: report.ErrorPriority,
+	Status:   report.Fail,
+	Scored:   true,
+}
+
+var minimalResult = report.Result{
+	Message:  "validation error: label required. Rule app-label-required failed at path /spec/template/spec/containers/0/resources/requests/",
+	Policy:   "app-label-requirement",
+	Priority: report.CriticalPriority,
 	Status:   report.Fail,
 	Scored:   true,
 }
@@ -118,7 +126,7 @@ func Test_TeamsTarget(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if payload["themeColor"] != "e20b0b" {
+			if payload["themeColor"] != "b80707" {
 				t.Errorf("Unexpected ThemeColor %s", payload["themeColor"])
 			}
 		}
@@ -142,6 +150,23 @@ func Test_TeamsTarget(t *testing.T) {
 
 		client := teams.NewClient("http://hook.teams:80", "", false, testClient{callback, 200})
 		client.Send(minimalInfoResult)
+	})
+	t.Run("Send Minimal ErrorResult", func(t *testing.T) {
+		callback := func(req *http.Request) {
+			payload := make(map[string]interface{})
+
+			err := json.NewDecoder(req.Body).Decode(&payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if payload["themeColor"] != "e20b0b" {
+				t.Errorf("Unexpected ThemeColor %s", payload["themeColor"])
+			}
+		}
+
+		client := teams.NewClient("http://hook.teams:80", "", false, testClient{callback, 200})
+		client.Send(minimalErrorResult)
 	})
 	t.Run("Send Minimal Debug Result", func(t *testing.T) {
 		callback := func(req *http.Request) {

--- a/pkg/target/ui/ui_test.go
+++ b/pkg/target/ui/ui_test.go
@@ -14,7 +14,7 @@ var completeResult = report.Result{
 	Rule:     "autogen-check-for-requests-and-limits",
 	Priority: report.WarningPriority,
 	Status:   report.Fail,
-	Severity: report.Heigh,
+	Severity: report.High,
 	Category: "resources",
 	Scored:   true,
 	Resources: []report.Resource{


### PR DESCRIPTION
* Support Priority by Severity
    * high -> critical
    * medium -> warning
    * low -> information
* Severity is added as label to result metrics
* Severity is added in Policy Reporter UI tables