### PR TITLE
Customize label and annotation for Grafana dashboards

### DIFF
--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: monitoring
   repository: ""
-  version: 1.3.0
+  version: 1.4.0
 - name: ui
   repository: ""
   version: 1.7.0
 - name: kyvernoPlugin
   repository: ""
   version: 0.4.0
-digest: sha256:821f124786b218565a1d8473ed7331f2c84aa9cc7a271660f2702881fb85c1d4
-generated: "2021-06-10T12:13:32.300743+02:00"
+digest: sha256:a9d7eea930c844c76395d400e2f224f538e3f5e93a011926e31915f239509915
+generated: "2021-06-26T22:23:24.195707238+02:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 1.7.3
+version: 1.8.0
 appVersion: 1.7.3
 
 dependencies:

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -6,7 +6,7 @@ description: |
 
 type: application
 version: 1.7.3
-appVersion: 1.8.0
+appVersion: 1.7.3
 
 dependencies:
   - name: monitoring

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -6,13 +6,13 @@ description: |
 
 type: application
 version: 1.7.3
-appVersion: 1.7.0
+appVersion: 1.8.0
 
 dependencies:
   - name: monitoring
     condition: monitoring.enabled
     repository: ""
-    version: "1.3.0"
+    version: "1.4.0"
   - name: ui
     condition: ui.enabled
     repository: ""

--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
@@ -3,8 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-clusterpolicy-details-dashboard
   namespace: {{ .Values.namespace }}
+  annotations:
+    {{ .Values.grafana.folder.annotation }}: {{ .Values.grafana.folder.name }}
   labels:
-    grafana_dashboard: "1"
+    {{ .Values.grafana.dashboards.label }}: "1"
     {{- include "monitoring.labels" . | nindent 4 }}
 data:
   cluster-policy-reporter-details-dashboard.json: |

--- a/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
@@ -3,8 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-overview-dashboard
   namespace: {{ .Values.namespace }}
+  annotations:
+    {{ .Values.grafana.folder.annotation }}: {{ .Values.grafana.folder.name }}
   labels:
-    grafana_dashboard: "1"
+    {{ .Values.grafana.dashboards.label }}: "1"
     {{- with .Values.serviceMonitor.labels }}
         {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
@@ -3,8 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-policy-details-dashboard
   namespace: {{ .Values.namespace }}
+  annotations:
+    {{ .Values.grafana.folder.annotation }}: {{ .Values.grafana.folder.name }}
   labels:
-    grafana_dashboard: "1"
+    {{ .Values.grafana.dashboards.label }}: "1"
     {{- with .Values.serviceMonitor.labels }}
         {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -15,7 +15,7 @@ grafana:
     # Annotation to enable folder storage using the k8s sidecar
     annotation: grafana_folder
     # Grafana folder in which to store the dashboards
-    name: kyverno
+    name: Policy Reporter
 
 policyReportDetails:
   firstStatusRow:

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -7,6 +7,16 @@ serviceMonitor:
   # labels to match the serviceMonitorSelector of the Prometheus Resource
   labels: {}
 
+grafana:
+  dashboards:
+    # Label to find dashboards using the k8s sidecar
+    label: grafana_dashboard
+  folder:
+    # Annotation to enable folder storage using the k8s sidecar
+    annotation: grafana_folder
+    # Grafana folder in which to store the dashboards
+    name: kyverno
+
 policyReportDetails:
   firstStatusRow:
     height: 8


### PR DESCRIPTION
- Add a feature to customize the label on the configmap to discover Grafana dashboards.
- Add an annotation to support Grafana folder name into the configmap.


