### PR TITLE
Add network policies

### DIFF
--- a/charts/policy-reporter/charts/ui/templates/networkpolicy.yaml
+++ b/charts/policy-reporter/charts/ui/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{ include "policyreporter.labels" . | nindent 4 }}
+  name: {{ include "policyreporter.fullname" . }}
+spec:
+  podSelector:
+    matchLabels: {{- include "ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+  egress:
+  - to:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+{{- end }}

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -1,5 +1,8 @@
 enabled: false
 
+networkPolicy:
+  enabled: false
+
 log:
   # holds the latest 200 validation results in the UI Log
   size: 200

--- a/charts/policy-reporter/templates/networkpolicy.yaml
+++ b/charts/policy-reporter/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ui.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{ include "policyreporter.labels" . | nindent 4 }}
+  name: {{ include "policyreporter.fullname" . }}
+spec:
+  podSelector:
+    matchLabels: {{- include "policyreporter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.port }} 
+  egress:
+  - to:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ui.service.port }} 
+{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -74,6 +74,9 @@ resources: {}
 # enable policy-report-ui
 ui:
   enabled: false
+  # Network Policy support, useful when running on a cluster configured with default deny policy
+  networkPolicy:
+    enabled: false
 
 kyvernoPlugin:
   enabled: false


### PR DESCRIPTION
These policies allow necessary traffic between the policy-report and policy-reporter-ui pods. This is useful on clusters where netpols are in use with a default-deny configuration.