### PR TITLE
Add NetworkPolicy support for core services

### DIFF
--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/networkpolicy.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/networkpolicy.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{- include "kyvernoplugin.labels" . | nindent 4 }}
+  name: {{ include "kyvernoplugin.fullname" . }}
+spec:
+  podSelector:
+    matchLabels: {{- include "kyvernoplugin.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.port }} 
+  - from:
+    ports:
+    - protocol: TCP
+      port: 2113
+{{- end }}

--- a/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -79,3 +79,8 @@ tolerations: []
 
 # Anti-affinity to disallow deploying client and master nodes on the same worker node
 affinity: {}
+
+# Enable a NetworkPolicy for this chart. Useful on clusters where Network Policies are
+# used and configured in a default-deny fashion.
+networkPolicy:
+  enabled: false

--- a/charts/policy-reporter/charts/ui/templates/networkpolicy.yaml
+++ b/charts/policy-reporter/charts/ui/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{ include "policyreporter.labels" . | nindent 4 }}
+  name: {{ include "policyreporter.fullname" . }}
+spec:
+  podSelector:
+    matchLabels: {{- include "ui.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+  egress:
+  - to:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+{{- end }}

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -99,3 +99,8 @@ tolerations: []
 
 # Anti-affinity to disallow deploying client and master nodes on the same worker node
 affinity: {}
+
+# Enable a NetworkPolicy for this chart. Useful on clusters where Network Policies are
+# used and configured in a default-deny fashion.
+networkPolicy:
+  enabled: false

--- a/charts/policy-reporter/templates/networkpolicy.yaml
+++ b/charts/policy-reporter/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{ include "policyreporter.labels" . | nindent 4 }}
+  name: {{ include "policyreporter.fullname" . }}
+spec:
+  podSelector:
+    matchLabels: {{- include "policyreporter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.port }} 
+  - from:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+  egress:
+  - to:
+    ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }} 
+{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -71,21 +71,17 @@ resources: {}
   #   memory: 20Mi
   #   cpu: 5m
 
+# Enable a NetworkPolicy for this chart. Useful on clusters where Network Policies are
+# used and configured in a default-deny fashion.
 networkPolicy:
   enabled: false
 
 # enable policy-report-ui
 ui:
   enabled: false
-  # Set this to true when enabling the UI and networkPolicy.enabled is true.
-  networkPolicy:
-    enabled: false
 
 kyvernoPlugin:
   enabled: false
-  # Set this to true when networkPolicy.enabled is true.
-  networkPolicy:
-    enabled: false
 
 monitoring:
   enabled: false

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -71,12 +71,21 @@ resources: {}
   #   memory: 20Mi
   #   cpu: 5m
 
+networkPolicy:
+  enabled: false
+
 # enable policy-report-ui
 ui:
   enabled: false
+  # Set this to true when enabling the UI and networkPolicy.enabled is true.
+  networkPolicy:
+    enabled: false
 
 kyvernoPlugin:
   enabled: false
+  # Set this to true when networkPolicy.enabled is true.
+  networkPolicy:
+    enabled: false
 
 monitoring:
   enabled: false


### PR DESCRIPTION
Signed-off-by: windowsrefund <mac>

This is a fresh attempt to add NetworkPolicy support for the policy-reporter, policy-reporter-ui, and policy-reporter-kyverno-plugin pods. Useful on clusters with Network Policies enabled in a default-deny configuration.