### PR TITLE
Make image registries configurable

### DIFF
--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "kyverno-plugin"
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext }}
           securityContext:

--- a/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -1,4 +1,5 @@
 image:
+  registry: docker.io
   repository: fjogeleit/policy-reporter-kyverno-plugin
   pullPolicy: IfNotPresent
   tag: 0.3.2

--- a/charts/policy-reporter/charts/ui/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/ui/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext }}
           securityContext:

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -8,6 +8,7 @@ plugins:
   kyverno: false
 
 image:
+  registry: docker.io
   repository: fjogeleit/policy-reporter-ui
   pullPolicy: IfNotPresent
   tag: 0.14.0

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext }}
           securityContext:

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1,4 +1,5 @@
 image:
+  registry: docker.io
   repository: fjogeleit/policy-reporter
   pullPolicy: IfNotPresent
   tag: 1.8.6


### PR DESCRIPTION
Hey :wave: first of all, thanks for maintaining this project! It's a really nice addition

We'd like to be able to template in alternative registries for running in environments where pulling from Docker Hub isn't an option. So, this PR adds that