### PR TITLE
Update kyverno-plugin ServiceMonitor port

### DIFF
--- a/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
@@ -16,5 +16,5 @@ spec:
     matchLabels:
         {{- include "kyvernoplugin.selectorLabels" . | nindent 8 }}
   endpoints:
-  - port: http
+  - port: rest
 {{- end }}


### PR DESCRIPTION
I'm seeing TargetDown alerts in prometheus for policy-reporter-kyverno-plugin when deploying helm chart with `monitoring.enabled: true`. I briefly probed exposed ports and found that `/metrics` endpoint is accessible via `rest` port.

I'm not sure whether this is expected behavior, maybe it's something that needs to be adjusted on kyverno-plugin side instead.