### PR TITLE
Removal of redundant values

### DIFF
--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -105,8 +105,6 @@ kyvernoPlugin:
 # Settings for the monitoring subchart
 monitoring:
   enabled: false
-  # DEPRECATED - only remains for backwards compatability
-  namespace: cattle-dashboards
 
 global:
   # available plugins

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -104,6 +104,8 @@ kyvernoPlugin:
 
 monitoring:
   enabled: false
+  # DEPRECATED - only remains for backwards compatability
+  namespace: cattle-dashboards
 
 global:
   # available plugins

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -104,11 +104,6 @@ kyvernoPlugin:
 
 monitoring:
   enabled: false
-  namespace: cattle-dashboards
-
-  serviceMonitor:
-    # labels to match the serviceMonitorSelector of the Prometheus Resource
-    labels: {}
 
 global:
   # available plugins

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -102,6 +102,7 @@ ui:
 kyvernoPlugin:
   enabled: false
 
+# Settings for the monitoring subchart
 monitoring:
   enabled: false
   # DEPRECATED - only remains for backwards compatability


### PR DESCRIPTION
In [`values.yaml`](https://github.com/kyverno/policy-reporter/blob/main/charts/policy-reporter/values.yaml), `monitoring.namespace: cattle-dashboards` leads the developer to think that this namespace is where Grafana should be located on the cluster. However from [`charts/policy-reporter/charts/monitoring/templates/_helpers.tpl`](https://github.com/kyverno/policy-reporter/blob/main/charts/policy-reporter/charts/monitoring/templates/_helpers.tpl#L46), it should actually be `monitoring.grafana.namespace`.

This PR gives a description that `monitoring.namespace` should not be used and only remains due to backwards compatability (https://github.com/kyverno/policy-reporter/issues/92), and removes `monitoring.serviceMonitor` defaults which should be left to the monitoring subchart.