### PR TITLE
feat: add linux/s390x builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ build: prepare
 
 .PHONY: docker-build
 docker-build:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS)
 
 .PHONY: docker-push
 docker-push:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --push
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):$(IMAGE_TAG) . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):latest . --build-arg LD_FLAGS=$(LD_FLAGS) --push
 
 .PHONY: docker-push-dev
 docker-push-dev:
-	@docker buildx build --progress plane --platform linux/arm64,linux/amd64 --tag $(REPO):dev . --build-arg LD_FLAGS=$(LD_FLAGS) --push
+	@docker buildx build --progress plane --platform linux/arm64,linux/amd64,linux/s390x --tag $(REPO):dev . --build-arg LD_FLAGS=$(LD_FLAGS) --push


### PR DESCRIPTION
This PR adds builds for `linux/s390x` arch (to use it on zLinux).
There is a corresponding PR open in the `kyverno` repo to add support there as well:
https://github.com/kyverno/kyverno/pull/3277

Signed-off-by: skuethe <56306041+skuethe@users.noreply.github.com>