### PR TITLE
Make grafana dashboard label value configurable

### DIFF
--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: monitoring
   repository: ""
-  version: 2.3.0
+  version: 2.3.1
 - name: ui
   repository: ""
   version: 2.4.2
 - name: kyvernoPlugin
   repository: ""
   version: 1.3.1
-digest: sha256:f1686cfbc5de749d82c2020a8c546e70534e4d7cd154d74cf1380a5fc3dc91ee
-generated: "2022-06-09T23:43:09.479977+02:00"
+digest: sha256:2fcff214e5178f7c4cb22d0dce27b33a022bf9be46eeea22a4a81f0b2e4f1a4f
+generated: "2022-06-17T10:58:52.909430821-04:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.9.1
+version: 2.9.2
 appVersion: 2.6.1
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   - name: monitoring
     condition: monitoring.enabled
-    version: "2.3.0"
+    version: "2.3.1"
   - name: ui
     condition: ui.enabled
     version: "2.4.2"

--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 2.3.0
+version: 2.3.1
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
@@ -10,7 +10,7 @@ metadata:
         {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    {{ .Values.grafana.dashboards.label }}: "1"
+    {{ .Values.grafana.dashboards.label }}:  {{ .Values.grafana.dashboards.value }}
     {{- include "monitoring.labels" . | nindent 4 }}
 data:
   cluster-policy-reporter-details-dashboard.json: |

--- a/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
@@ -10,7 +10,7 @@ metadata:
         {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    {{ .Values.grafana.dashboards.label }}: "1"
+    {{ .Values.grafana.dashboards.label }}: {{ .Values.grafana.dashboards.value }}
     {{- with .Values.serviceMonitor.labels }}
         {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
@@ -10,7 +10,7 @@ metadata:
         {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    {{ .Values.grafana.dashboards.label }}: "1"
+    {{ .Values.grafana.dashboards.label }}: {{ .Values.grafana.dashboards.value }}
     {{- with .Values.serviceMonitor.labels }}
         {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -5,7 +5,7 @@ plugins:
 annotations: {}
 
 serviceMonitor:
-  # allow to override the namespace for serviceMonitor  
+  # allow to override the namespace for serviceMonitor
   namespace:
   # labels to match the serviceMonitorSelector of the Prometheus Resource
   labels: {}
@@ -26,7 +26,7 @@ grafana:
   namespace:
   dashboards:
     # Enable the deployment of grafana dashboards
-    enabled: true 
+    enabled: true
     # Label to find dashboards using the k8s sidecar
     label: grafana_dashboard
     value: "1"

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -29,6 +29,7 @@ grafana:
     enabled: true 
     # Label to find dashboards using the k8s sidecar
     label: grafana_dashboard
+    value: "1"
   folder:
     # Annotation to enable folder storage using the k8s sidecar
     annotation: grafana_folder


### PR DESCRIPTION
The default label for grafana to detect and load a dashboard from a ConfigMap is `grafana_dashboard: "1"`. The monitoring chart already allows specifying a different label, but not a different value. This PR makes the value configurable as well, in case other users would also like to use different values than the default "1".