### PR TITLE
Adding extra volumes usage possibility

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.11.3
+version: 2.11.4
 appVersion: 2.8.2
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             subPath: config.yaml
             {{- end }}
             readOnly: true
+          {{- with .Values.extraVolumes.volumeMounts }}
+          {{ toYaml . | nindent 10 | trim }}
+          {{- end }}
           {{- if or .Values.leaderElection.enabled (gt (int .Values.replicaCount) 1) }}
           env:
           - name: POD_NAME
@@ -104,6 +107,9 @@ spec:
           secretName: {{ include "policyreporter.fullname" . }}-config
           {{- end }}
           optional: true
+      {{- with .Values.extraVolumes.volumes }}
+      {{ toYaml . | nindent 6 | trim }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -456,3 +456,8 @@ readinessProbe:
   httpGet:
     path: /healthz
     port: http
+
+extraVolumes:
+  volumeMounts: []
+
+  volumes: []


### PR DESCRIPTION
Hello. It would be good, if we can add some volumes over values. For example, I want to add custom CA certs into pod and use s3-compatible internal storage as a target.