### PR TITLE
add honorLabels setting

### DIFF
--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 2.4.1
+version: 2.5.0
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "kyvernoplugin.selectorLabels" . | nindent 8 }}
   endpoints:
   - port: rest
+    honorLabels: {{ .Values.kyverno.serviceMonitor.honorLabels }}
     relabelings:
     - action: labeldrop
       regex: pod|service|container

--- a/charts/policy-reporter/charts/monitoring/templates/servicemonitor.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/servicemonitor.yaml
@@ -18,6 +18,7 @@ spec:
         {{- include "policyreporter.selectorLabels" . | nindent 8 }}
   endpoints:
   - port: http
+    honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     relabelings:
     - action: labeldrop
       regex: pod|service|container

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -5,6 +5,8 @@ plugins:
 annotations: {}
 
 serviceMonitor:
+  # HonorLabels chooses the metrics labels on collisions with target labels
+  honorLabels: false
   # allow to override the namespace for serviceMonitor
   namespace:
   # labels to match the serviceMonitorSelector of the Prometheus Resource
@@ -16,6 +18,8 @@ serviceMonitor:
 
 kyverno:
   serviceMonitor:
+    # HonorLabels chooses the metrics labels on collisions with target labels
+    honorLabels: false
     # see serviceMonitor.relabelings
     relabelings: []
     # see serviceMonitor.relabelings


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

* add honorLabels setting to monitoring chart
* if set to true the labels from the exporter are used
* false (current behaviour) means that "namespace" label would be scraped as "exported_namespace"

Imho default could be "true" too but that would need changes to the Grafana dashboards as well.