### PR TITLE
Add default prometheus annotations

### DIFF
--- a/manifest/policy-reporter/install.yaml
+++ b/manifest/policy-reporter/install.yaml
@@ -73,6 +73,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: policy-reporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
     spec:
       serviceAccountName: policy-reporter
       automountServiceAccountToken: true


### PR DESCRIPTION
The static manifests don't configure Policy Reporter with the annotations required for a [default helm installed Prometheus](https://artifacthub.io/packages/helm/prometheus-community/prometheus#scraping-pod-metrics-via-annotations) to scrape metrics. This PR adds those annotations so Prometheus automatically finds the Policy Reporter pod as a scrape target:

![image](https://user-images.githubusercontent.com/855189/210912264-907622d4-9618-4d5e-9a77-945576e139c0.png)


![image](https://user-images.githubusercontent.com/855189/210912168-4f82debc-43bb-48be-a53d-ce9f52ccf449.png)

I also noted the default helm install has metrics disabled and the template has support for users to set their own pod annotations.