### PR TITLE
Add nameOverride to charts

### DIFF
--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: monitoring
   repository: ""
-  version: 2.6.0
+  version: 2.7.0
 - name: ui
   repository: ""
-  version: 2.7.2
+  version: 2.8.0
 - name: kyvernoPlugin
   repository: ""
   version: 1.5.1
-digest: sha256:42373a4f89c43d3b1edb0ba7945d281306af1c135e3dba8c2619d12871e63085
-generated: "2023-01-22T13:11:51.032276+01:00"
+digest: sha256:0aae5d507bf0978650c79559a04154de8ad37bb9222c3a3292730538180a4fd0
+generated: "2023-01-24T07:59:12.707808-07:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -18,10 +18,10 @@ maintainers:
 dependencies:
   - name: monitoring
     condition: monitoring.enabled
-    version: "2.6.0"
+    version: "2.7.0"
   - name: ui
     condition: ui.enabled
-    version: "2.7.2"
+    version: "2.8.0"
   - name: kyvernoPlugin
     condition: kyvernoPlugin.enabled
     version: "1.5.1"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.15.0
+version: 2.16.0
 appVersion: 2.12.0
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 2.6.0
+version: 2.7.0
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/monitoring/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/monitoring/templates/_helpers.tpl
@@ -4,7 +4,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "monitoring.fullname" -}}
-{{- $name := .Chart.Name }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if .Values.global.fullnameOverride }}
 {{- printf "%s-%s" .Values.global.fullnameOverride $name | trunc 63 | trimSuffix "-" }}
 {{- else if contains $name .Release.Name }}

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -1,3 +1,6 @@
+# Override the chart name used for all resources
+nameOverride: ""
+
 plugins:
   kyverno: false
 

--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 2.7.2
+version: 2.8.0
 appVersion: 1.7.2

--- a/charts/policy-reporter/charts/ui/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/ui/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: {{ include "ui.serviceAccountName" . }}
       automountServiceAccountToken: false
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ default .Chart.Name .Values.nameOverride }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext }}

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -1,5 +1,8 @@
 enabled: false
 
+# Override the chart name used for all resources
+nameOverride: ""
+
 image:
   registry: ghcr.io
   repository: kyverno/policy-reporter-ui

--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -8,7 +8,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "policyreporter.fullname" -}}
-{{- $name := .Chart.Name }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if .Values.global.fullnameOverride }}
 {{- .Values.global.fullnameOverride }}
 {{- else if contains $name .Release.Name }}

--- a/charts/policy-reporter/templates/cronjob-summary-report.yaml
+++ b/charts/policy-reporter/templates/cronjob-summary-report.yaml
@@ -51,7 +51,7 @@ spec:
           {{- end }}
           restartPolicy: {{ .Values.emailReports.summary.restartPolicy }}
           containers:
-            - name: {{ .Chart.Name }}
+            - name: {{ default .Chart.Name .Values.nameOverride }}
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.securityContext }}

--- a/charts/policy-reporter/templates/cronjob-violations-report.yaml
+++ b/charts/policy-reporter/templates/cronjob-violations-report.yaml
@@ -51,7 +51,7 @@ spec:
           {{- end }}
           restartPolicy: {{ .Values.emailReports.violations.restartPolicy }}
           containers:
-            - name: {{ .Chart.Name }}
+            - name: {{ default .Chart.Name .Values.nameOverride }}
               image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.securityContext }}

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ default .Chart.Name .Values.nameOverride }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1,3 +1,6 @@
+# Override the chart name used for all resources
+nameOverride: ""
+
 image:
   registry: ghcr.io
   repository: kyverno/policy-reporter


### PR DESCRIPTION
More context is provided in the issue this closes, but the goal is to provide a `nameOverride` to each chart that makes use of `.Chart.Name`. This value overrides the chart name anywhere it is used for labels/container names/etc.

Fixes https://github.com/kyverno/policy-reporter/issues/253

Signed-off-by: Micah Nagel <micah.nagel@defenseunicorns.com>