### PR TITLE
refactor: cache lib

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,32 +1,6 @@
 package cache
 
-import (
-	"time"
-
-	gocache "github.com/patrickmn/go-cache"
-)
-
 type Cache interface {
 	Has(id string) bool
 	Add(id string)
-}
-
-type InMemoryCache struct {
-	cache *gocache.Cache
-}
-
-func (c *InMemoryCache) Has(id string) bool {
-	_, ok := c.cache.Get(id)
-
-	return ok
-}
-
-func (c *InMemoryCache) Add(id string) {
-	c.cache.SetDefault(id, true)
-}
-
-func New(defaultExpiration, cleanupInterval time.Duration) *InMemoryCache {
-	return &InMemoryCache{
-		cache: gocache.New(defaultExpiration, cleanupInterval),
-	}
 }

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+)
+
+type inMemoryCache struct {
+	cache *gocache.Cache
+}
+
+func (c *inMemoryCache) Has(id string) bool {
+	_, ok := c.cache.Get(id)
+
+	return ok
+}
+
+func (c *inMemoryCache) Add(id string) {
+	c.cache.SetDefault(id, true)
+}
+
+func NewInMermoryCache(defaultExpiration, cleanupInterval time.Duration) Cache {
+	return &inMemoryCache{
+		cache: gocache.New(defaultExpiration, cleanupInterval),
+	}
+}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -1,4 +1,4 @@
-package redis
+package cache
 
 import (
 	"context"
@@ -9,20 +9,20 @@ import (
 	goredis "github.com/go-redis/redis/v8"
 )
 
-type RedisCache struct {
+type redisCache struct {
 	rdb    *goredis.Client
 	prefix string
 	ttl    time.Duration
 }
 
-func (r *RedisCache) Add(id string) {
+func (r *redisCache) Add(id string) {
 	err := r.rdb.Set(context.Background(), r.generateKey(id), true, r.ttl).Err()
 	if err != nil {
 		log.Printf("[ERROR] Failed to set result: %s\n", err)
 	}
 }
 
-func (r *RedisCache) Has(id string) bool {
+func (r *redisCache) Has(id string) bool {
 	_, err := r.rdb.Get(context.Background(), r.generateKey(id)).Result()
 	if err == goredis.Nil {
 		return false
@@ -34,10 +34,10 @@ func (r *RedisCache) Has(id string) bool {
 	return true
 }
 
-func (r *RedisCache) generateKey(id string) string {
+func (r *redisCache) generateKey(id string) string {
 	return fmt.Sprintf("%s:%s", r.prefix, id)
 }
 
-func New(prefix string, rdb *goredis.Client, ttl time.Duration) *RedisCache {
-	return &RedisCache{rdb: rdb, prefix: prefix, ttl: ttl}
+func NewRedisCache(prefix string, rdb *goredis.Client, ttl time.Duration) Cache {
+	return &redisCache{rdb: rdb, prefix: prefix, ttl: ttl}
 }

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/leaderelection"
 	"github.com/kyverno/policy-reporter/pkg/listener"
 	"github.com/kyverno/policy-reporter/pkg/listener/metrics"
-	"github.com/kyverno/policy-reporter/pkg/redis"
 	"github.com/kyverno/policy-reporter/pkg/report"
 	"github.com/kyverno/policy-reporter/pkg/sqlite3"
 	"github.com/kyverno/policy-reporter/pkg/target"
@@ -310,7 +309,7 @@ func (r *Resolver) ResultCache() cache.Cache {
 	}
 
 	if r.config.Redis.Enabled {
-		r.resultCache = redis.New(
+		r.resultCache = cache.NewRedisCache(
 			r.config.Redis.Prefix,
 			goredis.NewClient(&goredis.Options{
 				Addr:     r.config.Redis.Address,
@@ -321,7 +320,7 @@ func (r *Resolver) ResultCache() cache.Cache {
 			2*time.Hour,
 		)
 	} else {
-		r.resultCache = cache.New(time.Minute*150, time.Minute*15)
+		r.resultCache = cache.NewInMermoryCache(time.Minute*150, time.Minute*15)
 	}
 
 	return r.resultCache

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -3,9 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/kyverno/policy-reporter/pkg/cache"
 	"github.com/kyverno/policy-reporter/pkg/config"
-	"github.com/kyverno/policy-reporter/pkg/redis"
 	"github.com/kyverno/policy-reporter/pkg/report"
 	"k8s.io/client-go/rest"
 )
@@ -227,10 +225,6 @@ func Test_ResolveAPIServer(t *testing.T) {
 func Test_ResolveCache(t *testing.T) {
 	t.Run("InMemory", func(t *testing.T) {
 		resolver := config.NewResolver(testConfig, &rest.Config{})
-		_, ok := resolver.ResultCache().(*cache.InMemoryCache)
-		if !ok {
-			t.Error("Expected Cache to be InMemory Cache")
-		}
 
 		cache1 := resolver.ResultCache()
 		if cache1 == nil {
@@ -252,9 +246,10 @@ func Test_ResolveCache(t *testing.T) {
 		}
 
 		resolver := config.NewResolver(redisConfig, &rest.Config{})
-		_, ok := resolver.ResultCache().(*redis.RedisCache)
-		if !ok {
-			t.Error("Expected Cache to be Redis Cache")
+
+		cache1 := resolver.ResultCache()
+		if cache1 == nil {
+			t.Error("Error: Should return ResultCache")
 		}
 	})
 }

--- a/pkg/listener/new_result_test.go
+++ b/pkg/listener/new_result_test.go
@@ -15,7 +15,7 @@ func Test_ResultListener(t *testing.T) {
 	t.Run("Publish Result", func(t *testing.T) {
 		var called v1alpha2.PolicyReportResult
 
-		slistener := listener.NewResultListener(true, cache.New(0, 5*time.Minute), time.Now())
+		slistener := listener.NewResultListener(true, cache.NewInMermoryCache(0, 5*time.Minute), time.Now())
 		slistener.RegisterListener(func(_ v1alpha2.ReportInterface, r v1alpha2.PolicyReportResult, b bool) {
 			called = r
 		})
@@ -30,7 +30,7 @@ func Test_ResultListener(t *testing.T) {
 	t.Run("Ignore Delete Event", func(t *testing.T) {
 		var called bool
 
-		slistener := listener.NewResultListener(true, cache.New(0, 5*time.Minute), time.Now())
+		slistener := listener.NewResultListener(true, cache.NewInMermoryCache(0, 5*time.Minute), time.Now())
 		slistener.RegisterListener(func(_ v1alpha2.ReportInterface, r v1alpha2.PolicyReportResult, b bool) {
 			called = true
 		})
@@ -45,7 +45,7 @@ func Test_ResultListener(t *testing.T) {
 	t.Run("Ignore Added Results created before startup", func(t *testing.T) {
 		var called bool
 
-		slistener := listener.NewResultListener(true, cache.New(0, 5*time.Minute), time.Now())
+		slistener := listener.NewResultListener(true, cache.NewInMermoryCache(0, 5*time.Minute), time.Now())
 		slistener.RegisterListener(func(_ v1alpha2.ReportInterface, r v1alpha2.PolicyReportResult, b bool) {
 			called = true
 		})
@@ -60,7 +60,7 @@ func Test_ResultListener(t *testing.T) {
 	t.Run("Ignore CacheResults", func(t *testing.T) {
 		var called bool
 
-		rcache := cache.New(0, 5*time.Minute)
+		rcache := cache.NewInMermoryCache(0, 5*time.Minute)
 		rcache.Add(fixtures.FailPodResult.ID)
 
 		slistener := listener.NewResultListener(true, rcache, time.Now())
@@ -78,7 +78,7 @@ func Test_ResultListener(t *testing.T) {
 	t.Run("Early Return if Results are empty", func(t *testing.T) {
 		var called bool
 
-		rcache := cache.New(0, 5*time.Minute)
+		rcache := cache.NewInMermoryCache(0, 5*time.Minute)
 		rcache.Add(fixtures.FailPodResult.ID)
 
 		slistener := listener.NewResultListener(true, rcache, time.Now())


### PR DESCRIPTION
This PR refactors cache lib:
- only expose the cache interface
- add constructors to build either in memory or redis based cache