### PR TITLE
chore: store nil in the cache as we don't need the value

### DIFF
--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -17,7 +17,7 @@ func (c *inMemoryCache) Has(id string) bool {
 }
 
 func (c *inMemoryCache) Add(id string) {
-	c.cache.SetDefault(id, true)
+	c.cache.SetDefault(id, nil)
 }
 
 func NewInMermoryCache(defaultExpiration, cleanupInterval time.Duration) Cache {


### PR DESCRIPTION
This PR stores `nil` in the cache as we don't need the value back.