### PR TITLE
Feature/use mount secret

### DIFF
--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -158,6 +158,7 @@ s3:
   accessKeyID: {{ .Values.target.s3.accessKeyID }}
   secretAccessKey:  {{ .Values.target.s3.secretAccessKey }}
   secretRef: {{ .Values.target.s3.secretRef | quote }}
+  mountedSecret: {{ .Values.target.s3.mountedSecret }}
   region: {{ .Values.target.s3.region }}
   endpoint: {{ .Values.target.s3.endpoint }}
   bucket: {{ .Values.target.s3.bucket }}

--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -162,7 +162,7 @@ s3:
   endpoint: {{ .Values.target.s3.endpoint }}
   bucket: {{ .Values.target.s3.bucket }}
   bucketKeyEnabled: {{ .Values.target.s3.bucketKeyEnabled }}
-  sseKmsKeyId: {{ .Values.target.s3.sseKmsKeyId }}
+  kmsKeyId: {{ .Values.target.s3.kmsKeyId }}
   serverSideEncryption: { .Values.target.s3.serverSideEncryption }}
   pathStyle: {{ .Values.target.s3.pathStyle }}
   prefix: {{ .Values.target.s3.prefix }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -272,6 +272,8 @@ target:
     skipTLS: false
     # receive the host from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # loki api path, defaults to "/api/prom/push" (deprecated)
     path: ""
     # minimum priority "" < info < warning < critical < error
@@ -320,6 +322,8 @@ target:
     password: ""
     # receive the host, username and/or password from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # elasticsearch index rotation and index suffix
     # possible values: daily, monthly, annually, none (default: daily)
     rotation: ""
@@ -341,6 +345,8 @@ target:
     webhook: ""
     # receive the webhook from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # list of sources which should send to slack
@@ -374,6 +380,8 @@ target:
     webhook: ""
     # receive the webhook from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # minimum priority "" < info < warning < critical < error
     minimumPriority: ""
     # list of sources which should send to discord
@@ -390,6 +398,8 @@ target:
     webhook: ""
     # receive the webhook from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # path to your custom certificate
     # can be added under extraVolumes
     certificate: ""
@@ -431,6 +441,8 @@ target:
     skipTLS: false
     # receive the host and/or token from an existing secret, the token is added as Authorization header
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # additional http headers
     headers: {}
     # minimum priority "" < info < warning < critical < error
@@ -453,6 +465,8 @@ target:
     secretAccessKey: ""
     # receive the accessKeyID and/or secretAccessKey from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # S3 storage region
     region: ""
     # S3 storage endpoint
@@ -489,6 +503,8 @@ target:
     secretAccessKey: ""
     # receive the accessKeyID and/or secretAccessKey from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # AWS region
     region: ""
     # AWS Kinesis endpoint
@@ -513,6 +529,8 @@ target:
     credentials: ""
     # receive the credentials from an existing secret instead
     secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
     # GCS Bucket
     bucket: ""
     # minimum priority "" < info < warning < critical < error

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -462,7 +462,7 @@ target:
     # S3 storage to use an S3 Bucket Key for object encryption with SSE-KMS
     bucketKeyEnabled: false
     # S3 storage KMS Key ID for object encryption with SSE-KMS
-    sseKmsKeyId: ""
+    kmsKeyId: ""
     # S3 storage server-side encryption algorithm used when storing this object in Amazon S3, AES256, aws:kms
     serverSideEncryption: ""
     # S3 storage, force path style configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ type S3 struct {
 	Prefix               string            `mapstructure:"prefix"`
 	Bucket               string            `mapstructure:"bucket"`
 	BucketKeyEnabled     bool              `mapstructure:"bucketKeyEnabled"`
-	SseKmsKeyId          string            `mapstructure:"sseKmsKeyId"`
+	KmsKeyId             string            `mapstructure:"kmsKeyId"`
 	ServerSideEncryption string            `mapstructure:"serverSideEncryption"`
 	PathStyle            bool              `mapstructure:"pathStyle"`
 	SecretRef            string            `mapstructure:"secretRef"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ type Loki struct {
 	Certificate     string            `mapstructure:"certificate"`
 	Path            string            `mapstructure:"path"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomLabels    map[string]string `mapstructure:"customLabels"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -53,6 +54,7 @@ type Elasticsearch struct {
 	Username        string            `mapstructure:"username"`
 	Password        string            `mapstructure:"password"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -66,6 +68,7 @@ type Slack struct {
 	Name            string            `mapstructure:"name"`
 	Webhook         string            `mapstructure:"webhook"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -79,6 +82,7 @@ type Discord struct {
 	Name            string            `mapstructure:"name"`
 	Webhook         string            `mapstructure:"webhook"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -92,6 +96,7 @@ type Teams struct {
 	Name            string            `mapstructure:"name"`
 	Webhook         string            `mapstructure:"webhook"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipTLS         bool              `mapstructure:"skipTLS"`
 	Certificate     string            `mapstructure:"certificate"`
@@ -120,6 +125,7 @@ type Webhook struct {
 	Certificate     string            `mapstructure:"certificate"`
 	Headers         map[string]string `mapstructure:"headers"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -142,6 +148,7 @@ type S3 struct {
 	ServerSideEncryption string            `mapstructure:"serverSideEncryption"`
 	PathStyle            bool              `mapstructure:"pathStyle"`
 	SecretRef            string            `mapstructure:"secretRef"`
+	MountedSecret        string            `mapstructure:"mountedSecret"`
 	CustomFields         map[string]string `mapstructure:"customFields"`
 	SkipExisting         bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority      string            `mapstructure:"minimumPriority"`
@@ -159,6 +166,7 @@ type Kinesis struct {
 	Endpoint        string            `mapstructure:"endpoint"`
 	StreamName      string            `mapstructure:"streamName"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`
@@ -174,6 +182,7 @@ type GCS struct {
 	Prefix          string            `mapstructure:"prefix"`
 	Bucket          string            `mapstructure:"bucket"`
 	SecretRef       string            `mapstructure:"secretRef"`
+	MountedSecret   string            `mapstructure:"mountedSecret"`
 	CustomFields    map[string]string `mapstructure:"customFields"`
 	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
 	MinimumPriority string            `mapstructure:"minimumPriority"`

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -85,7 +85,7 @@ var testConfig = &config.Config{
 		SecretAccessKey:      "SecretAccessKey",
 		Bucket:               "test",
 		BucketKeyEnabled:     false,
-		SseKmsKeyId:          "",
+		KmsKeyId:             "",
 		ServerSideEncryption: "",
 		SkipExisting:         true,
 		MinimumPriority:      "debug",

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+
 	_ "github.com/mattn/go-sqlite3"
 	"go.uber.org/zap"
-	"os"
 
 	"github.com/kyverno/policy-reporter/pkg/helper"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/secrets"
@@ -266,7 +267,6 @@ func (f *TargetFactory) createSlackClient(config Slack, parent Slack) target.Cli
 	}
 
 	if config.MountedSecret != "" {
-
 	}
 
 	if config.Webhook == "" {

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
 	_ "github.com/mattn/go-sqlite3"
 	"go.uber.org/zap"
+	"os"
 
 	"github.com/kyverno/policy-reporter/pkg/helper"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/secrets"
@@ -260,8 +261,12 @@ func (f *TargetFactory) GCSClients(config GCS) []target.Client {
 }
 
 func (f *TargetFactory) createSlackClient(config Slack, parent Slack) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
+	}
+
+	if config.MountedSecret != "" {
+
 	}
 
 	if config.Webhook == "" {
@@ -292,8 +297,8 @@ func (f *TargetFactory) createSlackClient(config Slack, parent Slack) target.Cli
 }
 
 func (f *TargetFactory) createLokiClient(config Loki, parent Loki) target.Client {
-	if config.SecretRef != "" {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Host == "" && parent.Host == "" {
@@ -338,8 +343,8 @@ func (f *TargetFactory) createLokiClient(config Loki, parent Loki) target.Client
 }
 
 func (f *TargetFactory) createElasticsearchClient(config Elasticsearch, parent Elasticsearch) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Host == "" && parent.Host == "" {
@@ -404,8 +409,8 @@ func (f *TargetFactory) createElasticsearchClient(config Elasticsearch, parent E
 }
 
 func (f *TargetFactory) createDiscordClient(config Discord, parent Discord) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Webhook == "" {
@@ -436,8 +441,8 @@ func (f *TargetFactory) createDiscordClient(config Discord, parent Discord) targ
 }
 
 func (f *TargetFactory) createTeamsClient(config Teams, parent Teams) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Webhook == "" {
@@ -480,8 +485,8 @@ func (f *TargetFactory) createTeamsClient(config Teams, parent Teams) target.Cli
 }
 
 func (f *TargetFactory) createWebhookClient(config Webhook, parent Webhook) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Host == "" {
@@ -533,8 +538,8 @@ func (f *TargetFactory) createWebhookClient(config Webhook, parent Webhook) targ
 }
 
 func (f *TargetFactory) createS3Client(config S3, parent S3) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Endpoint == "" && parent.Endpoint == "" {
@@ -625,8 +630,8 @@ func (f *TargetFactory) createS3Client(config S3, parent S3) target.Client {
 }
 
 func (f *TargetFactory) createKinesisClient(config Kinesis, parent Kinesis) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Endpoint == "" && parent.Endpoint == "" {
@@ -696,8 +701,8 @@ func (f *TargetFactory) createKinesisClient(config Kinesis, parent Kinesis) targ
 }
 
 func (f *TargetFactory) createGCSClient(config GCS, parent GCS) target.Client {
-	if config.SecretRef != "" && f.secretClient != nil {
-		f.mapSecretValues(&config, config.SecretRef)
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(&config, config.SecretRef, config.MountedSecret)
 	}
 
 	if config.Bucket == "" && parent.Bucket == "" {
@@ -753,11 +758,29 @@ func (f *TargetFactory) createGCSClient(config GCS, parent GCS) target.Client {
 	})
 }
 
-func (f *TargetFactory) mapSecretValues(config any, ref string) {
-	values, err := f.secretClient.Get(context.Background(), ref)
-	if err != nil {
-		zap.L().Warn("failed to get secret reference", zap.Error(err))
-		return
+func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
+	values := secrets.Values{}
+
+	if ref != "" {
+		secretValues, err := f.secretClient.Get(context.Background(), ref)
+		values = secretValues
+		if err != nil {
+			zap.L().Warn("failed to get secret reference", zap.Error(err))
+			return
+		}
+	}
+
+	if mountedSecret != "" {
+		file, err := os.ReadFile(mountedSecret)
+		if err != nil {
+			zap.L().Warn("failed to get mounted secret", zap.Error(err))
+			return
+		}
+		err = json.Unmarshal(file, &values)
+		if err != nil {
+			zap.L().Warn("failed to unmarshal mounted secret", zap.Error(err))
+			return
+		}
 	}
 
 	switch c := config.(type) {

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -591,8 +591,8 @@ func (f *TargetFactory) createS3Client(config S3, parent S3) target.Client {
 		config.BucketKeyEnabled = parent.BucketKeyEnabled
 	}
 
-	if config.SseKmsKeyId == "" {
-		config.SseKmsKeyId = parent.SseKmsKeyId
+	if config.KmsKeyId == "" {
+		config.KmsKeyId = parent.KmsKeyId
 	}
 
 	if config.ServerSideEncryption == "" {
@@ -606,7 +606,7 @@ func (f *TargetFactory) createS3Client(config S3, parent S3) target.Client {
 		config.Endpoint,
 		config.Bucket,
 		config.PathStyle,
-		helper.WithKMS(&config.BucketKeyEnabled, &config.SseKmsKeyId, &config.ServerSideEncryption),
+		helper.WithKMS(&config.BucketKeyEnabled, &config.KmsKeyId, &config.ServerSideEncryption),
 	)
 
 	sugar.Infof("%s configured", config.Name)
@@ -800,7 +800,7 @@ func (f *TargetFactory) mapSecretValues(config any, ref string) {
 			c.SecretAccessKey = values.SecretAccessKey
 		}
 		if values.KmsKeyId != "" {
-			c.SseKmsKeyId = values.KmsKeyId
+			c.KmsKeyId = values.KmsKeyId
 		}
 
 	case *Kinesis:

--- a/pkg/config/target_factory_test.go
+++ b/pkg/config/target_factory_test.go
@@ -171,7 +171,7 @@ func Test_ResolveTargetWithoutHost(t *testing.T) {
 		}
 	})
 	t.Run("S3.SSE-KMS-KEY-ID", func(t *testing.T) {
-		if len(factory.S3Clients(config.S3{Endpoint: "https://storage.yandexcloud.net", AccessKeyID: "access", SecretAccessKey: "secret", Region: "ru-central1", ServerSideEncryption: "aws:kms", SseKmsKeyId: "SseKmsKeyId"})) != 0 {
+		if len(factory.S3Clients(config.S3{Endpoint: "https://storage.yandexcloud.net", AccessKeyID: "access", SecretAccessKey: "secret", Region: "ru-central1", ServerSideEncryption: "aws:kms", KmsKeyId: "kmsKeyId"})) != 0 {
 			t.Error("Expected Client to be nil if server side encryption is not configured")
 		}
 	})

--- a/pkg/config/target_factory_test.go
+++ b/pkg/config/target_factory_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/secrets"
 )
 
-const secretName = "secret-values"
-const mountedSecret = "/tmp/secrets-9999"
+const (
+	secretName    = "secret-values"
+	mountedSecret = "/tmp/secrets-9999"
+)
 
 func newFakeClient() v1.SecretInterface {
 	return fake.NewSimpleClientset(&corev1.Secret{
@@ -52,7 +54,7 @@ func mountSecret() {
 		Credentials:     `{"token": "token", "type": "authorized_user"}`,
 	}
 	file, _ := json.MarshalIndent(secretValues, "", " ")
-	_ = os.WriteFile(mountedSecret, file, 0644)
+	_ = os.WriteFile(mountedSecret, file, 0o644)
 }
 
 var logger = zap.NewNop()

--- a/pkg/helper/aws.go
+++ b/pkg/helper/aws.go
@@ -21,17 +21,17 @@ type s3Client struct {
 	bucket               string
 	uploader             *s3manager.Uploader
 	bucketKeyEnabled     *bool
-	sseKmsKeyId          *string
+	kmsKeyId             *string
 	serverSideEncryption *string
 }
 
 type Options func(s *s3Client)
 
-func WithKMS(bucketKeyEnabled *bool, sseKmsKeyId, serverSideEncryption *string) Options {
+func WithKMS(bucketKeyEnabled *bool, kmsKeyId, serverSideEncryption *string) Options {
 	return func(s *s3Client) {
 		s.bucketKeyEnabled = bucketKeyEnabled
-		if *sseKmsKeyId != "" {
-			s.sseKmsKeyId = sseKmsKeyId
+		if *kmsKeyId != "" {
+			s.kmsKeyId = kmsKeyId
 		}
 
 		if *serverSideEncryption != "" {
@@ -46,7 +46,7 @@ func (s *s3Client) Upload(body *bytes.Buffer, key string) error {
 		Key:                  aws.String(key),
 		Body:                 body,
 		BucketKeyEnabled:     s.bucketKeyEnabled,
-		SSEKMSKeyId:          s.sseKmsKeyId,
+		SSEKMSKeyId:          s.kmsKeyId,
 		ServerSideEncryption: s.serverSideEncryption,
 	})
 	return err

--- a/pkg/kubernetes/secrets/client.go
+++ b/pkg/kubernetes/secrets/client.go
@@ -8,15 +8,15 @@ import (
 )
 
 type Values struct {
-	Host            string
-	Webhook         string
-	Username        string
-	Password        string
-	AccessKeyID     string
-	SecretAccessKey string
-	KmsKeyId        string
-	Token           string
-	Credentials     string
+	Host            string `json:"host,omitempty"`
+	Webhook         string `json:"webhook,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
+	AccessKeyID     string `json:"accessKeyID,omitempty"`
+	SecretAccessKey string `json:"secretAccessKey,omitempty"`
+	KmsKeyId        string `json:"kmsKeyId,omitempty"`
+	Token           string `json:"token,omitempty"`
+	Credentials     string `json:"credentials,omitempty"`
 }
 
 type Client interface {


### PR DESCRIPTION
Feature pull request to add support for mounted secrets. This opens possibilities to use Secrets Store CSI Driver for Kubernetes secrets.

Secrets CSI Driver can utilize for example AWS Secrets Manager Secrets and mount them into pod as a volume.

https://secrets-store-csi-driver.sigs.k8s.io/

In the implementation added support for mounted secrets does not exclude using k8s secret (secretRef), but rather can be used together.
If there is same secret in secrets as in mounted secret, the value from mounted secret will be used.

Mountet secret needs to be in json format with keys defined in kubernetes/secrets Values struct.
This PR also includes aligned kmsKeyId attribute across project, instead of sseKmsKeyId.