### PR TITLE
Fixed config.yaml in chart. fix customFields for kinesis target.

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.18.3
+version: 2.18.4
 appVersion: 2.14.1
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -165,7 +165,7 @@ s3:
   bucket: {{ .Values.target.s3.bucket }}
   bucketKeyEnabled: {{ .Values.target.s3.bucketKeyEnabled }}
   kmsKeyId: {{ .Values.target.s3.kmsKeyId }}
-  serverSideEncryption: { .Values.target.s3.serverSideEncryption }}
+  serverSideEncryption: {{ .Values.target.s3.serverSideEncryption }}
   pathStyle: {{ .Values.target.s3.pathStyle }}
   prefix: {{ .Values.target.s3.prefix }}
   minimumPriority: {{ .Values.target.s3.minimumPriority | quote }}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -34,7 +34,7 @@ func Load(cmd *cobra.Command) (*Config, error) {
 	v.AutomaticEnv()
 
 	if err := v.ReadInConfig(); err != nil {
-		log.Println("[INFO] No configuration file found")
+		log.Printf("[INFO] No configuration file found: %v\n", err)
 	}
 
 	if flag := cmd.Flags().Lookup("worker"); flag != nil {

--- a/pkg/target/http/model.go
+++ b/pkg/target/http/model.go
@@ -21,14 +21,15 @@ type Resource struct {
 
 // Result JSON structure for HTTP Requests
 type Result struct {
-	Message           string    `json:"message"`
-	Policy            string    `json:"policy"`
-	Rule              string    `json:"rule"`
-	Priority          string    `json:"priority"`
-	Status            string    `json:"status"`
-	Severity          string    `json:"severity,omitempty"`
-	Category          string    `json:"category,omitempty"`
-	Scored            bool      `json:"scored"`
-	Resource          Resource  `json:"resource"`
-	CreationTimestamp time.Time `json:"creationTimestamp"`
+	Message           string            `json:"message"`
+	Policy            string            `json:"policy"`
+	Rule              string            `json:"rule"`
+	Priority          string            `json:"priority"`
+	Status            string            `json:"status"`
+	Severity          string            `json:"severity,omitempty"`
+	Category          string            `json:"category,omitempty"`
+	Scored            bool              `json:"scored"`
+	Properties        map[string]string `json:"properties,omitempty"`
+	Resource          Resource          `json:"resource"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
 }

--- a/pkg/target/http/utils.go
+++ b/pkg/target/http/utils.go
@@ -72,6 +72,7 @@ func NewJSONResult(r v1alpha2.PolicyReportResult) Result {
 		Severity:          string(r.Severity),
 		Category:          r.Category,
 		Scored:            r.Scored,
+		Properties:        r.Properties,
 		Resource:          res,
 		CreationTimestamp: time.Unix(r.Timestamp.Seconds, int64(r.Timestamp.Nanos)),
 	}


### PR DESCRIPTION
I found that chart is broken because of typo in config,yaml, fixed.
Also it turns out that customFields property lost for kinesis target, also fixed.
without this change kinesis message `body.String()` looks like:
```
"{\"message\":\"validation rule 'check-seccomp' passed.\",\"policy\":\"restrict-seccomp\",\"rule\":\"check-seccomp\",\"priority\":\"\",\"status\":\"pass\",\"severity\":\"medium\",\"category\":\"Pod Security Standards (Baseline)\",\"scored\":true,\"resource\":{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"name\":\"pod-7f48ccb69b-29zcb\",\"namespace\":\"default\",\"uid\":\"acdb7b5c-62eb-4fc5-b291-f1c622a39015\"},\"creationTimestamp\":\"2023-04-05T23:46:10Z\"}\n"
```

@fjogeleit could you please look?