### PR TITLE
source attribute added to report.

### DIFF
--- a/pkg/target/http/model.go
+++ b/pkg/target/http/model.go
@@ -32,4 +32,5 @@ type Result struct {
 	Properties        map[string]string `json:"properties,omitempty"`
 	Resource          Resource          `json:"resource"`
 	CreationTimestamp time.Time         `json:"creationTimestamp"`
+	Source            string            `json:"source"`
 }

--- a/pkg/target/http/utils.go
+++ b/pkg/target/http/utils.go
@@ -75,6 +75,7 @@ func NewJSONResult(r v1alpha2.PolicyReportResult) Result {
 		Properties:        r.Properties,
 		Resource:          res,
 		CreationTimestamp: time.Unix(r.Timestamp.Seconds, int64(r.Timestamp.Nanos)),
+		Source:            r.Source,
 	}
 }
 


### PR DESCRIPTION
Hello @fjogeleit , I want to leverage `source` attribute from `v1alpha.policyReportResult` in reports pushed by policy-reporter. wdyt, is it possible to add this small change to policy reporter?