### PR TITLE
fix(helm:ingress): pass whole tls block

### DIFF
--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.7.1
 - name: ui
   repository: ""
-  version: 2.9.4
+  version: 2.9.5
 - name: kyvernoPlugin
   repository: ""
-  version: 1.5.4
-digest: sha256:8c60bb2f27f40a297021c1ed8ac5d52d0053e36f65f1d71ad296a7beff95dd70
-generated: "2023-05-02T09:19:51.799892+02:00"
+  version: 1.5.5
+digest: sha256:bd96fe77e2f2bf55dba6332a1e61241e494b1f20f1ac5a3bfa181a3d16146d3c
+generated: "2023-06-03T16:16:30.05684+03:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.19.2
+version: 2.19.3
 appVersion: 2.15.2
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
@@ -21,7 +21,7 @@ dependencies:
     version: "2.7.1"
   - name: ui
     condition: ui.enabled
-    version: "2.9.4"
+    version: "2.9.5"
   - name: kyvernoPlugin
     condition: kyvernoPlugin.enabled
-    version: "1.5.4"
+    version: "1.5.5"

--- a/charts/policy-reporter/charts/kyvernoPlugin/Chart.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/Chart.yaml
@@ -3,5 +3,5 @@ name: kyvernoPlugin
 description: Policy Reporter Kyverno Plugin
 
 type: application
-version: 1.5.4
+version: 1.5.5
 appVersion: 1.5.1

--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/ingress.yaml
@@ -34,14 +34,8 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 2.9.4
+version: 2.9.5
 appVersion: 1.8.4

--- a/charts/policy-reporter/charts/ui/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/ui/templates/ingress.yaml
@@ -34,14 +34,8 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/policy-reporter/templates/ingress.yaml
+++ b/charts/policy-reporter/templates/ingress.yaml
@@ -34,14 +34,8 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}


### PR DESCRIPTION
In our k8s cluster we use default ssl certificate, so we do not want to pass secretName for tls block. I suggest using this construction for passing tls block to have possibility to pass only hosts block without secretName.