### PR TITLE
Make inverval and scrapeTimeout configurable on ServiceMonitors

### DIFF
--- a/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/kyverno-servicemonitor.yaml
@@ -24,6 +24,12 @@ spec:
   endpoints:
   - port: rest
     honorLabels: {{ .Values.kyverno.serviceMonitor.honorLabels }}
+    {{- if .Values.kyverno.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kyverno.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.kyverno.serviceMonitor.interval }}
+    interval: {{ .Values.kyverno.serviceMonitor.interval }}
+    {{- end }}
     relabelings:
     - action: labeldrop
       regex: pod|service|container

--- a/charts/policy-reporter/charts/monitoring/templates/servicemonitor.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/servicemonitor.yaml
@@ -23,6 +23,12 @@ spec:
   endpoints:
   - port: http
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
     relabelings:
     - action: labeldrop
       regex: pod|service|container

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -20,7 +20,11 @@ serviceMonitor:
   metricRelabelings: []
   # optional namespaceSelector
   namespaceSelector: {}
-
+  # optional scrapeTimeout
+  scrapeTimeout:
+  # optional scrape interval
+  interval:
+  
 kyverno:
   serviceMonitor:
     # HonorLabels chooses the metrics labels on collisions with target labels
@@ -31,6 +35,10 @@ kyverno:
     metricRelabelings: []
     # optional namespaceSelector
     namespaceSelector: {}
+    # optional scrapeTimeout
+    scrapeTimeout:
+    # optional scrape interval
+    interval:
 
 grafana:
   # namespace for configMap of grafana dashboards


### PR DESCRIPTION
This PR makes the `interval` and `scrapeTimeout` fields of the monitoring chart ServiceMonitors configurable.

This aligns with how it is done in the Kyverno chart:
https://github.com/kyverno/kyverno/blob/main/charts/kyverno/templates/admission-controller/servicemonitor.yaml#L25:L26

