### PR TITLE
keep newline before rules

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.19.3
+version: 2.19.4
 appVersion: 2.15.2
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
@@ -21,7 +21,7 @@ dependencies:
     version: "2.7.1"
   - name: ui
     condition: ui.enabled
-    version: "2.9.5"
+    version: "2.9.6"
   - name: kyvernoPlugin
     condition: kyvernoPlugin.enabled
-    version: "1.5.5"
+    version: "1.5.6"

--- a/charts/policy-reporter/charts/kyvernoPlugin/Chart.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/Chart.yaml
@@ -3,5 +3,5 @@ name: kyvernoPlugin
 description: Policy Reporter Kyverno Plugin
 
 type: application
-version: 1.5.5
+version: 1.5.6
 appVersion: 1.5.1

--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.ingress.tls }}
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 2.9.5
+version: 2.9.6
 appVersion: 1.8.4

--- a/charts/policy-reporter/charts/ui/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/ui/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.ingress.tls }}
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/policy-reporter/templates/ingress.yaml
+++ b/charts/policy-reporter/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.ingress.tls }}
   tls:
     {{- toYaml .Values.ingress.tls | nindent 4 }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}


### PR DESCRIPTION
This PR fixes the issue, that rules are rendered o the same line as tls config.

fixes #323