### PR TITLE
feat: add securityContext at podlevel

### DIFF
--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:  {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "kyvernoplugin.serviceAccountName" . }}
       automountServiceAccountToken: true
       containers:

--- a/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -67,6 +67,9 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+podSecurityContext:
+  runAsUser: 1234
+  runAsGroup: 1234
 
 securityContext:
   runAsUser: 1234
@@ -140,12 +143,12 @@ logging:
 api:
   logging: false # enable debug API access logging, sets logLevel to debug
 
-# create PolicyReports for enforce policies, 
+# create PolicyReports for enforce policies,
 # based on Events created by Kyverno (>= v1.7.0)
 blockReports:
   enabled: false
   eventNamespace: default
-  results: 
+  results:
     maxPerReport: 200
     keepOnlyLatest: false
 


### PR DESCRIPTION
## Problem
Due to a Kyverno policy, I would like to be able to set the securityContext at podlevel for all Kyverno pods. The chart currently only offers the possibility to set the securityContext at container level. This causes my Kyverno policy to fail only for the `policy-reporter-kyverno-plugin-<random-string>` pod.

## Solution
I can optionally set the securityContext to podlevel with these incoming changes.