### PR TITLE
feat: add titlePrefix option (email reports)

### DIFF
--- a/charts/policy-reporter/config-email-reports.yaml
+++ b/charts/policy-reporter/config-email-reports.yaml
@@ -1,5 +1,6 @@
 emailReports:
   clusterName: {{ .Values.emailReports.clusterName }}
+  titlePrefix: {{ .Values.emailReports.titlePrefix }}
   {{- with .Values.emailReports.smtp }}
   smtp:
     {{- toYaml . | nindent 4 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -211,6 +211,7 @@ policyPriorities: {}
 
 emailReports:
   clusterName: "" # (optional) - displayed in the email report if configured
+  titlePrefix: "Report" # title prefix in the email subject
   smtp:
     secret: "" # (optional) secret name to provide the complete or partial SMTP configuration
     host: ""

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -202,6 +202,7 @@ To configure your SMTP server and receiver emails use the following configuratio
 ```yaml
 emailReports:
   clusterName: '' # optional clustername shown in the Report
+  titlePrefix: 'Report' # title prefix in the email subject
   smtp:
     host: ''
     port: 465

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,6 +179,7 @@ type EmailReports struct {
 	Summary     EmailReport    `mapstructure:"summary"`
 	Violations  EmailReport    `mapstructure:"violations"`
 	ClusterName string         `mapstructure:"clusterName"`
+	TitlePrefix string         `mapstructure:"titlePrefix"`
 }
 
 // API configuration

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -352,6 +352,7 @@ func (r *Resolver) SummaryReporter() *summary.Reporter {
 	return summary.NewReporter(
 		r.config.EmailReports.Templates.Dir,
 		r.config.EmailReports.ClusterName,
+		r.config.EmailReports.TitlePrefix,
 	)
 }
 
@@ -372,6 +373,7 @@ func (r *Resolver) ViolationsReporter() *violations.Reporter {
 	return violations.NewReporter(
 		r.config.EmailReports.Templates.Dir,
 		r.config.EmailReports.ClusterName,
+		r.config.EmailReports.TitlePrefix,
 	)
 }
 

--- a/pkg/email/model.go
+++ b/pkg/email/model.go
@@ -9,6 +9,7 @@ type Report struct {
 	Message     string
 	Format      string
 	ClusterName string
+	TitlePrefix string
 }
 
 type Reporter interface {

--- a/pkg/email/summary/reporter.go
+++ b/pkg/email/summary/reporter.go
@@ -11,6 +11,7 @@ import (
 type Reporter struct {
 	templateDir string
 	clusterName string
+	titlePrefix string
 }
 
 func (o *Reporter) Report(sources []Source, format string) (email.Report, error) {
@@ -24,19 +25,20 @@ func (o *Reporter) Report(sources []Source, format string) (email.Report, error)
 	err = templ.Execute(b, struct {
 		Sources     []Source
 		ClusterName string
-	}{Sources: sources, ClusterName: o.clusterName})
+		TitlePrefix string
+	}{Sources: sources, ClusterName: o.clusterName, TitlePrefix: o.titlePrefix})
 	if err != nil {
 		return email.Report{}, err
 	}
 
 	return email.Report{
 		ClusterName: o.clusterName,
-		Title:       "Summary Report from " + time.Now().Format("2006-01-02"),
+		Title:       o.titlePrefix + " (summary) on " + o.clusterName + " from " + time.Now().Format("2006-01-02"),
 		Message:     b.String(),
 		Format:      format,
 	}, nil
 }
 
-func NewReporter(templateDir, clusterName string) *Reporter {
-	return &Reporter{templateDir, clusterName}
+func NewReporter(templateDir, clusterName string, titlePrefix string) *Reporter {
+	return &Reporter{templateDir, clusterName, titlePrefix}
 }

--- a/pkg/email/summary/reporter_test.go
+++ b/pkg/email/summary/reporter_test.go
@@ -38,7 +38,7 @@ func Test_CreateReport(t *testing.T) {
 
 	fmt.Println(path)
 
-	reporter := summary.NewReporter("../../../templates", "Cluster")
+	reporter := summary.NewReporter("../../../templates", "Cluster", "Report")
 	report, err := reporter.Report(data, "html")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -49,6 +49,9 @@ func Test_CreateReport(t *testing.T) {
 	}
 	if report.ClusterName != "Cluster" {
 		t.Fatal("expected clustername to be set")
+	}
+	if report.TitlePrefix != "Report" {
+		t.Fatal("expected titleprefix to be set")
 	}
 	if report.Format != "html" {
 		t.Fatal("expected format to be set")

--- a/pkg/email/violations/reporter.go
+++ b/pkg/email/violations/reporter.go
@@ -11,6 +11,7 @@ import (
 type Reporter struct {
 	templateDir string
 	clusterName string
+	titlePrefix string
 }
 
 func (o *Reporter) Report(sources []Source, format string) (email.Report, error) {
@@ -36,19 +37,20 @@ func (o *Reporter) Report(sources []Source, format string) (email.Report, error)
 		Sources     []Source
 		Status      []string
 		ClusterName string
-	}{Sources: sources, Status: []string{"warn", "fail", "error"}, ClusterName: o.clusterName})
+		TitlePrefix string
+	}{Sources: sources, Status: []string{"warn", "fail", "error"}, ClusterName: o.clusterName, TitlePrefix: o.titlePrefix})
 	if err != nil {
 		return email.Report{}, err
 	}
 
 	return email.Report{
 		ClusterName: o.clusterName,
-		Title:       "Summary Report from " + time.Now().Format("2006-01-02"),
+		Title:       o.titlePrefix + " (violations) on " + o.clusterName + " from " + time.Now().Format("2006-01-02"),
 		Message:     b.String(),
 		Format:      format,
 	}, nil
 }
 
-func NewReporter(templateDir string, clusterName string) *Reporter {
-	return &Reporter{templateDir, clusterName}
+func NewReporter(templateDir string, clusterName string, titlePrefix string) *Reporter {
+	return &Reporter{templateDir, clusterName, titlePrefix}
 }

--- a/pkg/email/violations/reporter_test.go
+++ b/pkg/email/violations/reporter_test.go
@@ -38,7 +38,7 @@ func Test_CreateReport(t *testing.T) {
 
 	fmt.Println(path)
 
-	reporter := violations.NewReporter("../../../templates", "Cluster")
+	reporter := violations.NewReporter("../../../templates", "Cluster", "Report")
 	report, err := reporter.Report(data, "html")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -49,6 +49,9 @@ func Test_CreateReport(t *testing.T) {
 	}
 	if report.ClusterName != "Cluster" {
 		t.Fatal("expected clustername to be set")
+	}
+	if report.TitlePrefix != "Report" {
+		t.Fatal("expected titleprefix to be")
 	}
 	if report.Format != "html" {
 		t.Fatal("expected format to be set")


### PR DESCRIPTION
Description of this feature, in email subject:

* Use `titlePrefix` to override title prefix the prefix subject
* Clustername added

Before:

```
Summary Report from <date>
```

After (default):

```
Report (summary) on <clustername> from <date>
Report (violations) on <clustername> from <date>
```

Also with `titlePrefix="Policy-Reporter reporting"`:

```
Policy-Reporter reporting (summary) on <clustername> from <date>
Policy-Reporter reporting (violations) on <clustername> from <date>
```