### PR TITLE
Telegram push target support

### DIFF
--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -150,6 +150,33 @@ webhook:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+telegram:
+  token: {{ .Values.target.telegram.token | quote }}
+  chatID: {{ .Values.target.telegram.chatID | quote }}
+  host: {{ .Values.target.telegram.host | quote }}
+  certificate: {{ .Values.target.telegram.certificate | quote }}
+  skipTLS: {{ .Values.target.telegram.skipTLS }}
+  secretRef: {{ .Values.target.telegram.secretRef | quote }}
+  mountedSecret: {{ .Values.target.telegram.mountedSecret | quote }}
+  minimumPriority: {{ .Values.target.telegram.minimumPriority | quote }}
+  skipExistingOnStartup: {{ .Values.target.telegram.skipExistingOnStartup }}
+  {{- with .Values.target.telegram.sources }}
+  sources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.target.telegram.customFields }}
+  customFields:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.target.telegram.filter }}
+  filter:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.target.telegram.channels }}
+  channels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 ui:
   host: {{ include "policyreporter.uihost" . }}
   certificate: {{ .Values.target.ui.certificate | quote }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -483,6 +483,37 @@ target:
     # add additional webhook channels with different configurations and filters
     channels: []
 
+  telegram:
+    # telegram bot token
+    token: ""
+    # telegram chat id
+    chatID: ""
+    # optional telegram proxy host
+    host: ""
+    # path to your custom certificate
+    # can be added under extraVolumes
+    certificate: ""
+    # skip TLS verification if necessary
+    skipTLS: false
+    # receive the host and/or token from an existing secret, the token is added as Authorization header
+    secretRef: ""
+    # Mounted secret path by Secrets Controller, secret should be in json format
+    mountedSecret: ""
+    # additional http headers
+    headers: {}
+    # minimum priority "" < info < warning < critical < error
+    minimumPriority: ""
+    # list of sources which should send to telegram
+    sources: []
+    # Skip already existing PolicyReportResults on startup
+    skipExistingOnStartup: true
+    # Added as additional properties to each notification
+    customFields: {}
+    # filter results send by namespaces, policies and priorities
+    filter: {}
+    # add additional telegram channels with different configurations and filters
+    channels: []
+
   s3:
     # S3 access key
     accessKeyID: ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,18 @@ type Webhook struct {
 	Channels          []Webhook         `mapstructure:"channels"`
 }
 
+// Telegram configuration
+type Telegram struct {
+	TargetBaseOptions `mapstructure:",squash"`
+	Host              string            `mapstructure:"host"`
+	Token             string            `mapstructure:"token"`
+	ChatID            string            `mapstructure:"chatID"`
+	SkipTLS           bool              `mapstructure:"skipTLS"`
+	Certificate       string            `mapstructure:"certificate"`
+	Headers           map[string]string `mapstructure:"headers"`
+	Channels          []Telegram        `mapstructure:"channels"`
+}
+
 type AWSConfig struct {
 	AccessKeyID     string `mapstructure:"accessKeyID"`
 	SecretAccessKey string `mapstructure:"secretAccessKey"`
@@ -282,6 +294,7 @@ type Config struct {
 	GCS            GCS            `mapstructure:"gcs"`
 	UI             UI             `mapstructure:"ui"`
 	Webhook        Webhook        `mapstructure:"webhook"`
+	Telegram       Telegram       `mapstructure:"telegram"`
 	API            API            `mapstructure:"api"`
 	WorkerCount    int            `mapstructure:"worker"`
 	DBFile         string         `mapstructure:"dbfile"`

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -279,6 +279,7 @@ func (r *Resolver) TargetClients() []target.Client {
 	clients = append(clients, factory.SecurityHubs(r.config.SecurityHub)...)
 	clients = append(clients, factory.WebhookClients(r.config.Webhook)...)
 	clients = append(clients, factory.GCSClients(r.config.GCS)...)
+	clients = append(clients, factory.TelegramClients(r.config.Telegram)...)
 
 	if ui := factory.UIClient(r.config.UI); ui != nil {
 		clients = append(clients, ui)

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -175,13 +175,22 @@ var testConfig = &config.Config{
 			Encryption: "ssl/tls",
 		},
 	},
+	Telegram: config.Telegram{
+		Token:  "XXX",
+		ChatID: "123456",
+		Channels: []config.Telegram{
+			{
+				ChatID: "1234567",
+			},
+		},
+	},
 }
 
 func Test_ResolveTargets(t *testing.T) {
 	resolver := config.NewResolver(testConfig, &rest.Config{})
 
-	if count := len(resolver.TargetClients()); count != 22 {
-		t.Errorf("Expected 22 Clients, got %d", count)
+	if count := len(resolver.TargetClients()); count != 24 {
+		t.Errorf("Expected 24 Clients, got %d", count)
 	}
 }
 

--- a/pkg/target/telegram/telegram.go
+++ b/pkg/target/telegram/telegram.go
@@ -1,0 +1,165 @@
+package telegram
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/http"
+)
+
+var replacer = strings.NewReplacer(
+	"_", "\\_", "*", "\\*", "[", "\\[", "]", "\\]", "(",
+	"\\(", ")", "\\)", "~", "\\~", "`", "\\`", ">", "\\>",
+	"#", "\\#", "+", "\\+", "-", "\\-", "=", "\\=", "|",
+	"\\|", "{", "\\{", "}", "\\}", ".", "\\.", "!", "\\!",
+)
+
+func escape(text interface{}) string {
+	return replacer.Replace(fmt.Sprintf("%v", text))
+}
+
+var (
+	notificationTempl = `*\[Policy Reporter\] \[{{ .Priority }}\] {{ escape (or .Result.Policy .Result.Rule) }}*
+{{- if .Resource }}
+
+*Resource*: {{ .Resource.Kind }} {{ if .Resource.Namespace }}{{ escape .Resource.Namespace }}/{{ end }}{{ escape .Resource.Name }}
+
+{{- end }}
+
+*Status*: {{ escape .Result.Result }}
+*Time*: {{ escape (.Time.Format "02 Jan 06 15:04 MST") }}
+
+{{ if .Result.Category }}*Category*: {{ escape .Result.Category }}{{ end }}
+{{ if .Result.Policy }}*Rule*: {{ escape .Result.Rule }}{{ end }}
+*Source*: {{ escape .Result.Source }}
+
+*Message*:
+
+{{ escape .Result.Message }}
+
+*Properties*:
+{{ range $key, $value := .Result.Properties }}• *{{ escape $key }}*: {{ escape $value }}
+{{ end }}
+`
+)
+
+type Payload struct {
+	Text                  string `json:"text,omitempty"`
+	ParseMode             string `json:"parse_mode,omitempty"`
+	DisableWebPagePreview bool   `json:"disable_web_page_preview,omitempty"`
+	ChatID                string `json:"chat_id,omitempty"`
+}
+
+type values struct {
+	Result   v1alpha2.PolicyReportResult
+	Time     time.Time
+	Resource *corev1.ObjectReference
+	Props    map[string]string
+	Priority string
+}
+
+// Options to configure the Discord target
+type Options struct {
+	target.ClientOptions
+	ChatID       string
+	Host         string
+	Headers      map[string]string
+	CustomFields map[string]string
+	HTTPClient   http.Client
+}
+
+type client struct {
+	target.BaseClient
+	chatID       string
+	host         string
+	headers      map[string]string
+	customFields map[string]string
+	client       http.Client
+}
+
+func (e *client) Send(result v1alpha2.PolicyReportResult) {
+	if len(e.customFields) > 0 {
+		props := make(map[string]string, 0)
+
+		for property, value := range e.customFields {
+			props[property] = value
+		}
+
+		for property, value := range result.Properties {
+			props[property] = value
+		}
+
+		result.Properties = props
+	}
+
+	payload := Payload{
+		ParseMode:             "MarkdownV2",
+		DisableWebPagePreview: true,
+		ChatID:                e.chatID,
+	}
+
+	var textBuffer bytes.Buffer
+
+	ttmpl, err := template.New("telegram").Funcs(template.FuncMap{"escape": escape}).Parse(notificationTempl)
+	if err != nil {
+		zap.L().Error(e.Name()+": PUSH FAILED", zap.Error(err))
+		return
+	}
+
+	var res *corev1.ObjectReference
+	if result.HasResource() {
+		res = result.GetResource()
+	}
+
+	var prio = result.Priority.String()
+	if prio == "" {
+		prio = v1alpha2.DebugPriority.String()
+	}
+
+	err = ttmpl.Execute(&textBuffer, values{
+		Result:   result,
+		Time:     time.Now(),
+		Resource: res,
+		Priority: prio,
+	})
+	if err != nil {
+		zap.L().Error(e.Name()+": PUSH FAILED", zap.Error(err))
+		return
+	}
+
+	payload.Text = textBuffer.String()
+
+	req, err := http.CreateJSONRequest(e.Name(), "POST", e.host, payload)
+	if err != nil {
+		zap.L().Error(e.Name()+": PUSH FAILED", zap.Error(err))
+		fmt.Println(err)
+		return
+	}
+
+	for header, value := range e.headers {
+		req.Header.Set(header, value)
+	}
+
+	resp, err := e.client.Do(req)
+	http.ProcessHTTPResponse(e.Name(), resp, err)
+}
+
+// NewClient creates a new loki.client to send Results to Elasticsearch
+func NewClient(options Options) target.Client {
+	return &client{
+		target.NewBaseClient(options.ClientOptions),
+		options.ChatID,
+		options.Host,
+		options.Headers,
+		options.CustomFields,
+		options.HTTPClient,
+	}
+}

--- a/pkg/target/telegram/telegram_test.go
+++ b/pkg/target/telegram/telegram_test.go
@@ -1,0 +1,79 @@
+package telegram_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kyverno/policy-reporter/pkg/fixtures"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/telegram"
+)
+
+type testClient struct {
+	callback   func(req *http.Request) error
+	statusCode int
+}
+
+func (c testClient) Do(req *http.Request) (*http.Response, error) {
+	err := c.callback(req)
+
+	return &http.Response{
+		StatusCode: c.statusCode,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, err
+}
+
+func Test_TelegramTarget(t *testing.T) {
+	t.Run("Send", func(t *testing.T) {
+		callback := func(req *http.Request) error {
+			if contentType := req.Header.Get("Content-Type"); contentType != "application/json; charset=utf-8" {
+				t.Errorf("Unexpected Content-Type: %s", contentType)
+			}
+
+			if agend := req.Header.Get("User-Agent"); agend != "Policy-Reporter" {
+				t.Errorf("Unexpected Host: %s", agend)
+			}
+
+			if url := req.URL.String(); url != "https://api.telegram.org/botXXX/sendMessage" {
+				t.Errorf("Unexpected Host: %s", url)
+			}
+
+			if value := req.Header.Get("X-Code"); value != "1234" {
+				t.Errorf("Unexpected Header X-Code: %s", value)
+			}
+
+			return nil
+		}
+
+		client := telegram.NewClient(telegram.Options{
+			ClientOptions: target.ClientOptions{
+				Name: "Telegram",
+			},
+			Host:         "https://api.telegram.org/botXXX/sendMessage",
+			Headers:      map[string]string{"X-Code": "1234"},
+			CustomFields: map[string]string{"cluster": "name"},
+			HTTPClient:   testClient{callback, 200},
+		})
+		client.Send(fixtures.CompleteTargetSendResult)
+
+		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
+			t.Error("expected customFields are not added to the actuel result")
+		}
+	})
+	t.Run("Name", func(t *testing.T) {
+		client := telegram.NewClient(telegram.Options{
+			ClientOptions: target.ClientOptions{
+				Name: "Telegram",
+			},
+			Host:       "https://api.telegram.org/botXXX/sendMessage",
+			Headers:    map[string]string{"X-Code": "1234"},
+			HTTPClient: testClient{},
+		})
+
+		if client.Name() != "Telegram" {
+			t.Errorf("Unexpected Name %s", client.Name())
+		}
+	})
+}


### PR DESCRIPTION
@EsDmitrii first draft of the Telegram Push Target support

* Requires Bot Token and ChatID
* Token can be provided as Secret or MountVolume
* Routing (Channel) support and TLS configuration

```yaml
telegram:
  chatID: "5235626040"
  token: "XXXXXXX:AAHmp3nGzcXIg-GALcxXFUv3IS5j2clwqiQ"
  minimumPriority: "warning"
  skipExistingOnStartup: true
  customFields:
    cluster: Minikube
```

<img width="474" alt="Bildschirmfoto 2023-09-04 um 12 04 10" src="https://github.com/kyverno/policy-reporter/assets/16627596/557ba720-ea6e-45e9-af23-9e37c02f54db">
