### PR TITLE
build: cache go mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@ ARG LD_FLAGS='-s -w -linkmode external -extldflags "-static"'
 ARG TARGETPLATFORM
 
 WORKDIR /app
-COPY . .
 
 RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
     export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2)
 
-RUN go env
+COPY go.* ./
+RUN go env && go mod download
 
-RUN go get -d -v \
-    && go install -v
+COPY . .
 
 RUN CGO_ENABLED=1 go build -ldflags="${LD_FLAGS}" -tags="sqlite_unlock_notify" -o /app/build/policyreporter -v
 


### PR DESCRIPTION
For local development, to remove the step where go modules are downloaded on every `docker build`, first copy only `go.mod` and `go.sum` to the Docker workspace.

This step only needs to be performed whenever one of those files changes.