### PR TITLE
Create clusterroles/bindings when service account is not managed

### DIFF
--- a/charts/policy-reporter/templates/clusterrole.yaml
+++ b/charts/policy-reporter/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/policy-reporter/templates/role.yaml
+++ b/charts/policy-reporter/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.serviceAccount.create .Values.rbac.enabled) (or .Values.leaderElection.enabled (gt (int .Values.replicaCount) 1)) -}}
+{{- if and .Values.rbac.enabled (or .Values.leaderElection.enabled (gt (int .Values.replicaCount) 1)) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/policy-reporter/templates/rolebinding.yaml
+++ b/charts/policy-reporter/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.serviceAccount.create .Values.rbac.enabled) (or .Values.leaderElection.enabled (gt (int .Values.replicaCount) 1)) -}}
+{{- if and .Values.rbac.enabled (or .Values.leaderElection.enabled (gt (int .Values.replicaCount) 1)) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/policy-reporter/templates/secret-role.yaml
+++ b/charts/policy-reporter/templates/secret-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.enabled -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/policy-reporter/templates/secret-rolebinding.yaml
+++ b/charts/policy-reporter/templates/secret-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.enabled -}}
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
rbac.enabled only should toggle these objects' creation
so they can be used with a pre-existing service account.