### PR TITLE
message label in custom mode

### DIFF
--- a/pkg/listener/metrics/model.go
+++ b/pkg/listener/metrics/model.go
@@ -60,6 +60,9 @@ var LabelGeneratorMapping = map[string]LabelCallback{
 	"status": func(m map[string]string, _ v1alpha2.ReportInterface, r v1alpha2.PolicyReportResult) {
 		m["status"] = string(r.Result)
 	},
+	"message": func(m map[string]string, _ v1alpha2.ReportInterface, r v1alpha2.PolicyReportResult) {
+		m["message"] = r.Message
+	},
 }
 
 func CreateLabelGenerator(labels []string, names []string) LabelGenerator {

--- a/pkg/listener/metrics/model_test.go
+++ b/pkg/listener/metrics/model_test.go
@@ -60,4 +60,8 @@ func Test_LabelMappings(t *testing.T) {
 	if val, ok := results["kind"]; !ok && val != "" {
 		t.Errorf("expected empty name without resource, got: %s", val)
 	}
+	metrics.LabelGeneratorMapping["message"](results, preport, fixtures.FailPodResult)
+	if val, ok := results["namespace"]; !ok && val != fixtures.FailPodResult.Message {
+		t.Errorf("expected result for message label not found: %s", val)
+	}
 }


### PR DESCRIPTION
optional `message` label in custom metrics mode.

Config for all details:

```yaml
metrics:
  enabled: true
  mode: custom
  customLabels: ["namespace", "rule", "policy", "report", "kind", "name", "status", "severity", "category", "source", "message"]
```