### PR TITLE
fix: allow not setting .Values.podSecurityContext for kyvernoPlugin

### DIFF
--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:  {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kyvernoplugin.serviceAccountName" . }}
       automountServiceAccountToken: true
       containers:


### PR DESCRIPTION
kyvernoPlugin sub chart breaks if unsetting .Values.podSecurityContext . This fixes it.