### PR TITLE
fix: Add chart parameters for setting revisionHistoryLimit

### DIFF
--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- include "kyvernoplugin.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if .Values.deploymentStrategy }}
   strategy:
     {{- toYaml .Values.deploymentStrategy | nindent 4 }}

--- a/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -10,6 +10,8 @@ priorityClassName: ""
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 deploymentStrategy: {}
   # rollingUpdate:
   #  maxSurge: 25%

--- a/charts/policy-reporter/charts/ui/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/ui/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "ui.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if .Values.deploymentStrategy }}
   strategy:
     {{- toYaml .Values.deploymentStrategy | nindent 4 }}

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -108,6 +108,8 @@ imagePullSecrets: []
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 deploymentStrategy: {}
   # rollingUpdate:
   #  maxSurge: 25%

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if .Values.deploymentStrategy }}
   strategy:
     {{- toYaml .Values.deploymentStrategy | nindent 4 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -13,6 +13,8 @@ priorityClassName: ""
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 deploymentStrategy: {}
   # rollingUpdate:
   #  maxSurge: 25%


### PR DESCRIPTION
Default value is 10, matching the implicit Kubernetes default.