### PR TITLE
[feature/issue_377] Allow additional env variables to be added

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.21.3
+version: 2.21.4
 appVersion: 2.17.4
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/templates/deployment.yaml
@@ -103,6 +103,9 @@ spec:
                 key: password
                 optional: false
           {{- end }}
+          {{- with .Values.envVars }}
+          {{- . | toYaml | trim | nindent 10 }}
+          {{- end }}
       volumes:
       - name: config-file
         secret:

--- a/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
+++ b/charts/policy-reporter/charts/kyvernoPlugin/values.yaml
@@ -91,6 +91,9 @@ podAnnotations: {}
 # Key/value pairs that are attached to pods.
 podLabels: {}
 
+# Allow additional env variables to be added
+envVars: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/policy-reporter/charts/ui/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/ui/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.envVars }}
+          {{- . | toYaml | trim | nindent 10 }}
+          {{- end }}
       volumes:
       - name: config-file
         configMap:

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -83,7 +83,7 @@ api:
 
 # use redis as external log storage instead of an in memory store
 # recommended when using a HA setup with more then one replica
-# to get all logs on each instance 
+# to get all logs on each instance
 redis:
   enabled: false
   address: ""
@@ -133,6 +133,9 @@ podAnnotations: {}
 
 # Key/value pairs that are attached to pods.
 podLabels: {}
+
+# Allow additional env variables to be added
+envVars: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           {{- end }}
+          {{- with .Values.envVars }}
+          {{- . | toYaml | trim | nindent 10 }}
+          {{- end }}
       volumes:
       - name: sqlite
         {{- if .Values.sqliteVolume }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -76,6 +76,9 @@ podAnnotations: {}
 # Key/value pairs that are attached to pods.
 podLabels: {}
 
+# Allow additional env variables to be added
+envVars: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Added the support for adding additional env variables to the policy reporter deployment.
It's needed as currently there is no way to add additional env variables to the main policy-reporter chart.