### PR TITLE
Feat/add elastic search api key authentication

### DIFF
--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -30,6 +30,7 @@ elasticsearch:
   skipTLS: {{ .Values.target.elasticsearch.skipTLS }}
   username: {{ .Values.target.elasticsearch.username | quote }}
   password: {{ .Values.target.elasticsearch.password | quote }}
+  apiKey: {{ .Values.target.elasticsearch.password | quote }}
   secretRef: {{ .Values.target.elasticsearch.secretRef | quote }}
   mountedSecret: {{ .Values.target.elasticsearch.mountedSecret | quote }}
   index: {{ .Values.target.elasticsearch.index | default "policy-reporter" | quote }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -362,7 +362,9 @@ target:
     username: ""
     # elasticsearch password für HTTP Basic Auth
     password: ""
-    # receive the host, username and/or password from an existing secret instead
+    # elasticsearch apiKey für apiKey authentication
+    apiKey: ""
+    # receive the host, username and/or password,apiKey from an existing secret instead
     secretRef: ""
     # Mounted secret path by Secrets Controller, secret should be in json format
     mountedSecret: ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,7 @@ type Elasticsearch struct {
 	Rotation          string           `mapstructure:"rotation"`
 	Username          string           `mapstructure:"username"`
 	Password          string           `mapstructure:"password"`
+	ApiKey            string           `mapstructure:"apiKey"`
 	Channels          []*Elasticsearch `mapstructure:"channels"`
 }
 

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -408,6 +408,7 @@ func (f *TargetFactory) createElasticsearchClient(config, parent *Elasticsearch)
 	setBool(&config.SkipTLS, parent.SkipTLS)
 	setFallback(&config.Username, parent.Username)
 	setFallback(&config.Password, parent.Password)
+	setFallback(&config.ApiKey, parent.ApiKey)
 	setFallback(&config.Index, parent.Index, "policy-reporter")
 	setFallback(&config.Rotation, parent.Rotation, elasticsearch.Daily)
 
@@ -420,6 +421,7 @@ func (f *TargetFactory) createElasticsearchClient(config, parent *Elasticsearch)
 		Host:          config.Host,
 		Username:      config.Username,
 		Password:      config.Password,
+		ApiKey:        config.ApiKey,
 		Rotation:      config.Rotation,
 		Index:         config.Index,
 		CustomFields:  config.CustomFields,
@@ -821,6 +823,9 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 		}
 		if values.Password != "" {
 			c.Password = values.Password
+		}
+		if values.ApiKey != "" {
+			c.ApiKey = values.ApiKey
 		}
 
 	case *S3:

--- a/pkg/config/target_factory_test.go
+++ b/pkg/config/target_factory_test.go
@@ -31,6 +31,7 @@ func newFakeClient() v1.SecretInterface {
 			"host":            []byte("http://localhost:9200"),
 			"username":        []byte("username"),
 			"password":        []byte("password"),
+			"apiKey":          []byte("apiKey"),
 			"webhook":         []byte("http://localhost:9200/webhook"),
 			"accessKeyID":     []byte("accessKeyID"),
 			"secretAccessKey": []byte("secretAccessKey"),
@@ -49,6 +50,7 @@ func mountSecret() {
 		Webhook:         "http://localhost:9200/webhook",
 		Username:        "username",
 		Password:        "password",
+		ApiKey:          "apiKey",
 		AccessKeyID:     "accessKeyId",
 		SecretAccessKey: "secretAccessKey",
 		KmsKeyID:        "kmsKeyId",
@@ -331,6 +333,11 @@ func Test_GetValuesFromSecret(t *testing.T) {
 		password := client.FieldByName("password").String()
 		if password != "password" {
 			t.Errorf("Expected password from secret, got %s", password)
+		}
+
+		apiKey := client.FieldByName("apiKey").String()
+		if apiKey != "apiKey" {
+			t.Errorf("Expected apiKey from secret, got %s", apiKey)
 		}
 	})
 
@@ -638,6 +645,11 @@ func Test_GetValuesFromMountedSecret(t *testing.T) {
 		password := client.FieldByName("password").String()
 		if password != "password" {
 			t.Errorf("Expected password from mounted secret, got %s", password)
+		}
+
+		apiKey := client.FieldByName("apiKey").String()
+		if apiKey != "apiKey" {
+			t.Errorf("Expected apiKey from secret, got %s", apiKey)
 		}
 	})
 

--- a/pkg/kubernetes/secrets/client.go
+++ b/pkg/kubernetes/secrets/client.go
@@ -16,6 +16,7 @@ type Values struct {
 	Channel         string `json:"channel,omitempty"`
 	Username        string `json:"username,omitempty"`
 	Password        string `json:"password,omitempty"`
+	ApiKey          string `json:"apiKey,omitempty"`
 	AccessKeyID     string `json:"accessKeyID,omitempty"`
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 	AccountID       string `json:"accountID,omitempty"`
@@ -85,6 +86,10 @@ func (c *k8sClient) Get(ctx context.Context, name string) (Values, error) {
 
 	if password, ok := secret.Data["password"]; ok {
 		values.Password = string(password)
+	}
+
+	if apiKey, ok := secret.Data["apiKey"]; ok {
+		values.ApiKey = string(apiKey)
 	}
 
 	if database, ok := secret.Data["database"]; ok {

--- a/pkg/kubernetes/secrets/client_test.go
+++ b/pkg/kubernetes/secrets/client_test.go
@@ -25,6 +25,7 @@ func newFakeClient() v1.SecretInterface {
 			"host":            []byte("http://localhost:9200"),
 			"username":        []byte("username"),
 			"password":        []byte("password"),
+			"apiKey":          []byte("apiKey"),
 			"webhook":         []byte("http://localhost:9200/webhook"),
 			"accessKeyID":     []byte("accessKeyID"),
 			"secretAccessKey": []byte("secretAccessKey"),
@@ -60,6 +61,10 @@ func Test_Client(t *testing.T) {
 
 		if values.Password != "password" {
 			t.Errorf("Unexpected Password: %s", values.Password)
+		}
+
+		if values.ApiKey != "apiKey" {
+			t.Errorf("Unexpected ApiKey: %s", values.ApiKey)
 		}
 
 		if values.AccessKeyID != "accessKeyID" {

--- a/pkg/target/elasticsearch/elasticsearch.go
+++ b/pkg/target/elasticsearch/elasticsearch.go
@@ -14,6 +14,7 @@ type Options struct {
 	Host         string
 	Username     string
 	Password     string
+	ApiKey       string
 	Index        string
 	Rotation     string
 	CustomFields map[string]string
@@ -37,6 +38,7 @@ type client struct {
 	index        string
 	username     string
 	password     string
+	apiKey       string
 	rotation     Rotation
 	customFields map[string]string
 	client       http.Client
@@ -76,6 +78,8 @@ func (e *client) Send(result v1alpha2.PolicyReportResult) {
 
 	if e.username != "" {
 		req.SetBasicAuth(e.username, e.password)
+	} else if e.apiKey != "" {
+		req.Header.Add("Authorization", "ApiKey "+e.apiKey)
 	}
 
 	resp, err := e.client.Do(req)
@@ -90,6 +94,7 @@ func NewClient(options Options) target.Client {
 		options.Index,
 		options.Username,
 		options.Password,
+		options.ApiKey,
 		options.Rotation,
 		options.CustomFields,
 		options.HTTPClient,

--- a/pkg/target/elasticsearch/elasticsearch_test.go
+++ b/pkg/target/elasticsearch/elasticsearch_test.go
@@ -50,6 +50,7 @@ func Test_ElasticsearchTarget(t *testing.T) {
 			Host:         "http://localhost:9200",
 			Username:     "username",
 			Password:     "password",
+			ApiKey:       "ApiKey",
 			Index:        "policy-reporter",
 			Rotation:     elasticsearch.Annually,
 			HTTPClient:   testClient{callback, 200},


### PR DESCRIPTION
# Add apiKey authentication method to elasticSearch target
## Problem
Currently, the only available method to authenticate elasticSearch target is by using username/password in a Basic Http Auth Method.
This is a limitation and implies using login credentials from a user in the integration
## Proposed Implementation
Adding the possibility to configure ApiKey authentication so the integration can be achieved by using an user personal apiKey instead of actual user credentials. 