### PR TITLE
🐛 Add /tmp volume for sqlite

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.21.4
+version: 2.21.5
 appVersion: 2.17.4
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             subPath: config.yaml
             {{- end }}
             readOnly: true
+          - name: tmp
+            mountPath: /tmp
           {{- with .Values.extraVolumes.volumeMounts }}
           {{ toYaml . | nindent 10 | trim }}
           {{- end }}
@@ -120,6 +122,12 @@ spec:
           secretName: {{ include "policyreporter.fullname" . }}-config
           {{- end }}
           optional: true
+      - name: tmp
+        {{- if .Values.tmpVolume }}
+          {{- toYaml .Values.tmpVolume | nindent 8 }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
       {{- with .Values.extraVolumes.volumes }}
       {{ toYaml . | nindent 6 | trim }}
       {{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -742,3 +742,8 @@ extraVolumes:
 sqliteVolume: {}
   # emptyDir:
   #   sizeLimit: 10Mi
+
+# If set the volume for /tmp is freely configurable below "- name: tmp". If no value is set an emptyDir is used.
+tmpVolume: {}
+  # emptyDir:
+  #   sizeLimit: 10Mi


### PR DESCRIPTION
The volume is required for temporary files, when the root filesystem is readonly

Fixes #362 