### PR TITLE
Add support for elasticSearch typeless API

### DIFF
--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -30,13 +30,14 @@ elasticsearch:
   skipTLS: {{ .Values.target.elasticsearch.skipTLS }}
   username: {{ .Values.target.elasticsearch.username | quote }}
   password: {{ .Values.target.elasticsearch.password | quote }}
-  apiKey: {{ .Values.target.elasticsearch.password | quote }}
+  apiKey: {{ .Values.target.elasticsearch.apiKey | quote }}
   secretRef: {{ .Values.target.elasticsearch.secretRef | quote }}
   mountedSecret: {{ .Values.target.elasticsearch.mountedSecret | quote }}
   index: {{ .Values.target.elasticsearch.index | default "policy-reporter" | quote }}
   rotation: {{ .Values.target.elasticsearch.rotation | default "daily" | quote }}
   minimumPriority: {{ .Values.target.elasticsearch.minimumPriority | quote }}
   skipExistingOnStartup: {{ .Values.target.elasticsearch.skipExistingOnStartup }}
+  typelessApi: {{ .Values.target.elasticsearch.typelessApi }}
   {{- with .Values.target.elasticsearch.sources }}
   sources:
     {{- toYaml . | nindent 4 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -377,6 +377,8 @@ target:
     sources: []
     # Skip already existing PolicyReportResults on startup
     skipExistingOnStartup: true
+    # https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0 keeping as false for retrocompatibility.
+    typelessApi: false
     # Added as additional properties to each elasticsearch event
     customFields: {}
     # filter results send by namespaces, policies and priorities

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,6 +110,7 @@ type Elasticsearch struct {
 	Password          string           `mapstructure:"password"`
 	ApiKey            string           `mapstructure:"apiKey"`
 	Channels          []*Elasticsearch `mapstructure:"channels"`
+	TypelessApi       bool             `mapstructure:"typelessApi"`
 }
 
 // Slack configuration

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -411,6 +411,7 @@ func (f *TargetFactory) createElasticsearchClient(config, parent *Elasticsearch)
 	setFallback(&config.ApiKey, parent.ApiKey)
 	setFallback(&config.Index, parent.Index, "policy-reporter")
 	setFallback(&config.Rotation, parent.Rotation, elasticsearch.Daily)
+	setBool(&config.TypelessApi, parent.TypelessApi)
 
 	config.MapBaseParent(parent.TargetBaseOptions)
 
@@ -426,6 +427,7 @@ func (f *TargetFactory) createElasticsearchClient(config, parent *Elasticsearch)
 		Index:         config.Index,
 		CustomFields:  config.CustomFields,
 		HTTPClient:    http.NewClient(config.Certificate, config.SkipTLS),
+		TypelessApi:   config.TypelessApi,
 	})
 }
 
@@ -826,6 +828,9 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 		}
 		if values.ApiKey != "" {
 			c.ApiKey = values.ApiKey
+		}
+		if values.TypelessApi != false {
+			c.TypelessApi = values.TypelessApi
 		}
 
 	case *S3:

--- a/pkg/config/target_factory_test.go
+++ b/pkg/config/target_factory_test.go
@@ -40,6 +40,7 @@ func newFakeClient() v1.SecretInterface {
 			"credentials":     []byte(`{"token": "token", "type": "authorized_user"}`),
 			"database":        []byte("database"),
 			"dsn":             []byte(""),
+			"typelessApi":     []byte("false"),
 		},
 	}).CoreV1().Secrets("default")
 }
@@ -58,6 +59,7 @@ func mountSecret() {
 		Credentials:     `{"token": "token", "type": "authorized_user"}`,
 		Database:        "database",
 		DSN:             "",
+		TypelessApi:     false,
 	}
 	file, _ := json.MarshalIndent(secretValues, "", " ")
 	_ = os.WriteFile(mountedSecret, file, 0o644)
@@ -338,6 +340,11 @@ func Test_GetValuesFromSecret(t *testing.T) {
 		apiKey := client.FieldByName("apiKey").String()
 		if apiKey != "apiKey" {
 			t.Errorf("Expected apiKey from secret, got %s", apiKey)
+		}
+
+		typelessApi := client.FieldByName("typelessApi").Bool()
+		if typelessApi != false {
+			t.Errorf("Expected typelessApi false value from secret, got %t", typelessApi)
 		}
 	})
 
@@ -650,6 +657,11 @@ func Test_GetValuesFromMountedSecret(t *testing.T) {
 		apiKey := client.FieldByName("apiKey").String()
 		if apiKey != "apiKey" {
 			t.Errorf("Expected apiKey from secret, got %s", apiKey)
+		}
+
+		typelessApi := client.FieldByName("typelessApi").Bool()
+		if typelessApi != false {
+			t.Errorf("Expected typelessApi false value from secret, got %t", typelessApi)
 		}
 	})
 

--- a/pkg/kubernetes/secrets/client.go
+++ b/pkg/kubernetes/secrets/client.go
@@ -3,6 +3,8 @@ package secrets
 import (
 	"context"
 
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +27,7 @@ type Values struct {
 	Credentials     string `json:"credentials,omitempty"`
 	Database        string `json:"database,omitempty"`
 	DSN             string `json:"dsn,omitempty"`
+	TypelessApi     bool   `json:"typelessApi,omitempty"`
 }
 
 type Client interface {
@@ -122,6 +125,13 @@ func (c *k8sClient) Get(ctx context.Context, name string) (Values, error) {
 
 	if credentials, ok := secret.Data["credentials"]; ok {
 		values.Credentials = string(credentials)
+	}
+
+	if typelessApi, ok := secret.Data["typelessApi"]; ok {
+		values.TypelessApi, err = strconv.ParseBool(string(typelessApi))
+		if err != nil {
+			values.TypelessApi = false
+		}
 	}
 
 	return values, nil

--- a/pkg/kubernetes/secrets/client_test.go
+++ b/pkg/kubernetes/secrets/client_test.go
@@ -34,6 +34,7 @@ func newFakeClient() v1.SecretInterface {
 			"accountID":       []byte("accountID"),
 			"database":        []byte("database"),
 			"dsn":             []byte("dsn"),
+			"typelessApi":     []byte("false"),
 		},
 	}).CoreV1().Secrets("default")
 }
@@ -93,6 +94,10 @@ func Test_Client(t *testing.T) {
 
 		if values.DSN != "dsn" {
 			t.Errorf("Unexpected DSN: %s", values.DSN)
+		}
+
+		if values.TypelessApi {
+			t.Errorf("Unexpected TypelessApi: %t", values.TypelessApi)
 		}
 	})
 

--- a/pkg/target/elasticsearch/elasticsearch.go
+++ b/pkg/target/elasticsearch/elasticsearch.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
 	"github.com/kyverno/policy-reporter/pkg/target"
 	"github.com/kyverno/policy-reporter/pkg/target/http"
-	"go.uber.org/zap"
 )
 
 // Options to configure elasticsearch target
@@ -88,15 +87,11 @@ func (e *client) Send(result v1alpha2.PolicyReportResult) {
 		return
 	}
 
-	zap.L().Info("ElasticSearch ApiKey" + e.apiKey)
-
 	if e.username != "" {
 		req.SetBasicAuth(e.username, e.password)
 	} else if e.apiKey != "" {
 		req.Header.Add("Authorization", "ApiKey "+e.apiKey)
 	}
-
-	zap.L().Info("ElasticSearch Authorization Header" + req.Header.Get("Authorization"))
 
 	resp, err := e.client.Do(req)
 	http.ProcessHTTPResponse(e.Name(), resp, err)


### PR DESCRIPTION
### Support for elastic search typeless API
## Problem
As described in [elastic docs](https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0). Starting from elastic version 8.0 APIs that accept types are removed and a new endpoint needs to be called.

## Proposed Solution
Introduce a new configuration variable to enable usage of new endpoint to send data when using ES>8.0