### PR TITLE
Allow labels to be set on ingress

### DIFF
--- a/charts/policy-reporter/charts/ui/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/ui/templates/ingress.yaml
@@ -19,6 +19,11 @@ metadata:
   namespace: {{ include "ui.namespace" . }}
   labels:
     {{- include "ui.labels" . | nindent 4 }}
+    {{- if .Values.ingress.labels }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
   {{- if or .Values.annotations .Values.ingress.annotations }}
   annotations:
   {{- with .Values.ingress.annotations }}

--- a/charts/policy-reporter/templates/ingress.yaml
+++ b/charts/policy-reporter/templates/ingress.yaml
@@ -19,6 +19,11 @@ metadata:
   namespace: {{ include "policyreporter.namespace" . }}
   labels:
     {{- include "policyreporter.labels" . | nindent 4 }}
+    {{- if .Values.ingress.labels }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
   {{- if or .Values.annotations .Values.ingress.annotations }}
   annotations:
   {{- with .Values.ingress.annotations }}


### PR DESCRIPTION
Closes #391 

```
ingress:
  enabled: true
  className: "test"
  # key/value
  labels:
    something: special
  # key/value
  annotations:
    {}
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
  hosts:
    - host: chart-example.local
      paths: []
  tls: []
  #  - secretName: chart-example-tls
  #    hosts:
  #      - chart-example.local
```
yields

```
# Source: policy-reporter/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-policy-reporter
  namespace: default
  labels:
    helm.sh/chart: policy-reporter-2.21.5
    app.kubernetes.io/name: policy-reporter
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.17.4"
    app.kubernetes.io/component: reporting
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: policy-reporter
    something: special
spec:
  ingressClassName: test
  rules:
    - host: "chart-example.local"
      http:
        paths:
```