### PR TITLE
Add basic auth to loki client

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,8 @@ type Loki struct {
 	Certificate       string            `mapstructure:"certificate"`
 	Path              string            `mapstructure:"path"`
 	Channels          []*Loki           `mapstructure:"channels"`
+	Username          string            `mapstructure:"username"`
+	Password          string            `mapstructure:"password"`
 }
 
 // Elasticsearch configuration

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -371,6 +371,8 @@ func (f *TargetFactory) createLokiClient(config, parent *Loki) target.Client {
 	setFallback(&config.Certificate, parent.Certificate)
 	setFallback(&config.Path, parent.Path)
 	setBool(&config.SkipTLS, parent.SkipTLS)
+	setFallback(&config.Username, parent.Username)
+	setFallback(&config.Password, parent.Password)
 
 	config.MapBaseParent(parent.TargetBaseOptions)
 
@@ -391,6 +393,8 @@ func (f *TargetFactory) createLokiClient(config, parent *Loki) target.Client {
 		Host:          config.Host + config.Path,
 		CustomLabels:  config.CustomFields,
 		HTTPClient:    http.NewClient(config.Certificate, config.SkipTLS),
+		Username:      config.Username,
+		Password:      config.Password,
 	})
 }
 
@@ -798,6 +802,12 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 	case *Loki:
 		if values.Host != "" {
 			c.Host = values.Host
+		}
+		if values.Username != "" {
+			c.Username = values.Username
+		}
+		if values.Password != "" {
+			c.Password = values.Password
 		}
 
 	case *Slack:

--- a/pkg/config/target_factory_test.go
+++ b/pkg/config/target_factory_test.go
@@ -298,9 +298,20 @@ func Test_GetValuesFromSecret(t *testing.T) {
 			t.Fatal("Expected one client created")
 		}
 
-		fv := reflect.ValueOf(clients[0]).Elem().FieldByName("host")
-		if v := fv.String(); v != "http://localhost:9200/api/prom/push" {
+		client := reflect.ValueOf(clients[0]).Elem()
+
+		if v := client.FieldByName("host").String(); v != "http://localhost:9200/api/prom/push" {
 			t.Errorf("Expected host from secret, got %s", v)
+		}
+
+		username := client.FieldByName("username").String()
+		if username != "username" {
+			t.Errorf("Expected username from secret, got %s", username)
+		}
+
+		password := client.FieldByName("password").String()
+		if password != "password" {
+			t.Errorf("Expected password from secret, got %s", password)
 		}
 	})
 
@@ -625,10 +636,21 @@ func Test_GetValuesFromMountedSecret(t *testing.T) {
 			t.Error("Expected one client created")
 		}
 
-		fv := reflect.ValueOf(clients[0]).Elem().FieldByName("host")
-		if v := fv.String(); v != "http://localhost:9200/api/prom/push" {
+		client := reflect.ValueOf(clients[0]).Elem()
+		if v := client.FieldByName("host").String(); v != "http://localhost:9200/api/prom/push" {
 			t.Errorf("Expected host from mounted secret, got %s", v)
 		}
+
+		username := client.FieldByName("username").String()
+		if username != "username" {
+			t.Errorf("Expected username from mounted secret, got %s", username)
+		}
+
+		password := client.FieldByName("password").String()
+		if password != "password" {
+			t.Errorf("Expected password from mounted secret, got %s", password)
+		}
+
 	})
 
 	t.Run("Get Elasticsearch values from MountedSecret", func(t *testing.T) {

--- a/pkg/target/loki/loki.go
+++ b/pkg/target/loki/loki.go
@@ -15,6 +15,8 @@ type Options struct {
 	Host         string
 	CustomLabels map[string]string
 	HTTPClient   http.Client
+	Username     string
+	Password     string
 }
 
 type payload struct {
@@ -92,6 +94,8 @@ type client struct {
 	host         string
 	client       http.Client
 	customLabels map[string]string
+	username     string
+	password     string
 }
 
 func (l *client) Send(result v1alpha2.PolicyReportResult) {
@@ -101,6 +105,9 @@ func (l *client) Send(result v1alpha2.PolicyReportResult) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	if l.username != "" {
+		req.SetBasicAuth(l.username, l.password)
+	}
 
 	resp, err := l.client.Do(req)
 	http.ProcessHTTPResponse(l.Name(), resp, err)
@@ -113,5 +120,7 @@ func NewClient(options Options) target.Client {
 		options.Host,
 		options.HTTPClient,
 		options.CustomLabels,
+		options.Username,
+		options.Password,
 	}
 }

--- a/pkg/target/loki/loki_test.go
+++ b/pkg/target/loki/loki_test.go
@@ -40,6 +40,10 @@ func Test_LokiTarget(t *testing.T) {
 				t.Errorf("Unexpected Host: %s", url)
 			}
 
+			if req.Header.Get("Authorization") == "" {
+				t.Error("Expected Authentication header for BasicAuth is set")
+			}
+
 			expectedLine := fmt.Sprintf("[%s] %s", strings.ToUpper(fixtures.CompleteTargetSendResult.Priority.String()), fixtures.CompleteTargetSendResult.Message)
 			labels, line := convertAndValidateBody(req, t)
 			if line != expectedLine {
@@ -95,6 +99,8 @@ func Test_LokiTarget(t *testing.T) {
 			Host:         "http://localhost:3100/api/prom/push",
 			CustomLabels: map[string]string{"custom": "label"},
 			HTTPClient:   testClient{callback, 200},
+			Username:     "username",
+			Password:     "password",
 		})
 		client.Send(fixtures.CompleteTargetSendResult)
 	})


### PR DESCRIPTION
This adds basic auth to the loki client by using provided username password.

Grafana advises to run loki with a proxy, we use one with basic auth.

Thx in advance!