### PR TITLE
feat(helm): support unset security contexts in UI deployment

### DIFF
--- a/charts/policy-reporter/templates/ui/deployment.yaml
+++ b/charts/policy-reporter/templates/ui/deployment.yaml
@@ -34,12 +34,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "ui.serviceAccountName" . }}
+      {{- if .Values.ui.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.ui.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.ui.securityContext }}
           securityContext:
             {{- toYaml .Values.ui.securityContext | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.ui.image.registry }}/{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           args:


### PR DESCRIPTION
Our target clusters are OpenShift, and to set security contexts on OpenShift you usually need an SCC. Since no elevated permissions are required for the workloads in this project, we prefer to NOT set securityContexts. This PR makes it possible.

````
$ helm template charts/policy-reporter/ --set "ui.enabled=true" | grep securityContext
      securityContext:
          securityContext:
      securityContext:
          securityContext:

$ helm template charts/policy-reporter/ --set "podSecurityContext=null,securityContext=null,ui.enabled=true,ui.podSecurityContext=null,ui.securityContext=null" | grep securityContext
````