### PR TITLE
fix(helm): allow custom TLS settings for UI ingress

### DIFF
--- a/charts/policy-reporter/templates/ui/ingress.yaml
+++ b/charts/policy-reporter/templates/ui/ingress.yaml
@@ -32,13 +32,7 @@ spec:
   {{- end }}
   {{- if .Values.ui.ingress.tls }}
   tls:
-    {{- range .Values.ui.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    {{- toYaml .Values.ui.ingress.tls | nindent 4 }}
   {{- end }}
   rules:
     {{- range .Values.ui.ingress.hosts }}


### PR DESCRIPTION
Our target clusters are OpenShift, and to get the cluster default edge-terminated ingress TLS, we need to be able to set some strange/special Ingress TLS settings. This was possible with the 2.x version of the chart, but not anymore. I think this fix will retain the previous behavior (non-breaking) and is also less complex IMO.

Our values look like this in this area:

````yaml
ui:
  enabled: true
  ingress:
    enabled: true
    hosts:
      - host: policy-reporter.apps.${CLUSTER_DOMAIN}
        paths:
          - path: /
            pathType: Prefix
    tls:
      - {}
````

Without this fix, this ends up becoming invalid:

````yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app.kubernetes.io/instance: policy-reporter-preview
    app.kubernetes.io/name: policy-reporter-ui
    app.kubernetes.io/version: 3.0.0-alpha
  name: policy-reporter-ui
spec:
  rules:
  - host: policy-reporter.apps.${CLUSTER_DOMAIN}
    http:
      paths:
      - backend:
          service:
            name: policy-reporter-ui
            port:
              number: 8080
        path: /
        pathType: Prefix
  tls:
  - hosts: null
    secretName: null
````

And it should look like this:

````yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app.kubernetes.io/component: ui
    app.kubernetes.io/instance: policy-reporter
    app.kubernetes.io/name: ui
    app.kubernetes.io/part-of: policy-reporter
    app.kubernetes.io/version: 1.9.2
  name: policy-reporter-ui
  namespace: kyverno
spec:
  rules:
  - host: policy-reporter.apps.${CLUSTER_DOMAIN}
    http:
      paths:
      - backend:
          service:
            name: policy-reporter-ui
            port:
              number: 8080
        path: /
        pathType: Prefix
  tls:
  - {}
````