### PR TITLE
Fix : correct typo when using global.annotations

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.22.4
+version: 2.22.5
 appVersion: 2.18.1
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/templates/ingress.yaml
+++ b/charts/policy-reporter/templates/ingress.yaml
@@ -30,7 +30,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.annotations }}
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
When using global.annotation with ingress, the templating errored with the following error :

```
Error: template: kyverno/charts/policy-reporter/templates/ingress.yaml:33:22: executing "kyverno/charts/policy-reporter/templates/ingress.yaml" at <.Values.annotations>: nil pointer evaluating interface {}.annotations

Use --debug flag to render out invalid YAML
```

This fixes it.