### PR TITLE
fix: use /healthz for liveness and /ready for readiness

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 2.22.5
+version: 2.22.6
 appVersion: 2.18.2
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -739,13 +739,13 @@ topologySpreadConstraints: []
 # livenessProbe for policy-reporter
 livenessProbe:
   httpGet:
-    path: /ready
+    path: /healthz
     port: http
 
 # readinessProbe for policy-reporter
 readinessProbe:
   httpGet:
-    path: /healthz
+    path: /ready
     port: http
 
 extraVolumes:


### PR DESCRIPTION
Probe endpoints  for policy-reporter seem reversed.