### PR TITLE
Added support of sidecars and extraManifests

### DIFF
--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 2.10.5
+version: 2.11.0
 appVersion: 1.9.2

--- a/charts/policy-reporter/charts/ui/Chart.yaml
+++ b/charts/policy-reporter/charts/ui/Chart.yaml
@@ -3,5 +3,5 @@ name: ui
 description: Policy Reporter UI
 
 type: application
-version: 2.11.0
+version: 2.10.5
 appVersion: 1.9.2

--- a/charts/policy-reporter/charts/ui/templates/deployment.yaml
+++ b/charts/policy-reporter/charts/ui/templates/deployment.yaml
@@ -88,6 +88,16 @@ spec:
           {{- with .Values.envVars }}
           {{- . | toYaml | trim | nindent 10 }}
           {{- end }}
+      {{- if .Values.sidecarContainers }}
+        {{- range $name, $spec :=  .Values.sidecarContainers }}
+        - name: {{ $name }}
+          {{- if kindIs "string" $spec }}
+            {{- tpl $spec $ | nindent 10 }}
+          {{- else }}
+            {{- toYaml $spec | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       volumes:
       - name: config-file
         configMap:

--- a/charts/policy-reporter/charts/ui/templates/extra-manifests.yaml
+++ b/charts/policy-reporter/charts/ui/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/charts/policy-reporter/charts/ui/templates/ingress.yaml
+++ b/charts/policy-reporter/charts/ui/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ui.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.ingress.port | default .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/charts/policy-reporter/charts/ui/templates/service.yaml
+++ b/charts/policy-reporter/charts/ui/templates/service.yaml
@@ -25,6 +25,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+{{- if .Values.service.additionalPorts }}
+{{ toYaml .Values.service.additionalPorts | indent 4 }}
+{{- end }}
   selector:
     {{- include "ui.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/policy-reporter/charts/ui/values.yaml
+++ b/charts/policy-reporter/charts/ui/values.yaml
@@ -11,6 +11,24 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.9.2
 
+# sidecarContainers - add more containers to Kyverno ui
+# Key/Value where Key is the sidecar `- name: <Key>`
+# Example:
+# for adding OAuth authentication to Kyverno ui
+#   sidecarContainers:
+#     oauth-proxy:
+#       image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+#       args:
+#       - --upstream=http://127.0.0.1:8080
+#       - --http-address=0.0.0.0:8081
+#       - ...
+#       ports:
+#       - containerPort: 8081
+#         name: oauth-proxy
+#         protocol: TCP
+#       resources: {}
+sidecarContainers: {}
+
 # possible default displayModes: light/dark
 displayMode: ""
 
@@ -172,6 +190,11 @@ service:
   type: ClusterIP
   # integer nubmer. This is port for service
   port: 8080
+  # additionalPorts:
+  # - name: authenticated
+  #   port: 8081
+  #   targetPort: 8081
+  additionalPorts: []
 
 # enabled if replicaCount > 1
 podDisruptionBudget:
@@ -193,13 +216,15 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  ## Redirect ingress to an additional defined port on the service
+  # port: 8081
   hosts:
     - host: chart-example.local
       paths: []
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
-  #      - chart-example.local
+  #      - chart-example.local 
 
 # Node labels for pod assignment
 # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -241,3 +266,14 @@ global:
     password: ""
     # read credentials from secret
     secretRef: ""
+
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #   labels:
+  #     name: kyverno-extra
+  #   data:
+  #     extra-data: "value"


### PR DESCRIPTION
What this PR does / why we need it:
Adding support of multiple container in the same pod (side car, like oAuth-proxy)

Adding support of additional ports on service

Adding support of authenticated UI via Oauth-proxy