### PR TITLE
URGENT: Feat: Add kind attribute in the Metrics filter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type MetricsFilter struct {
 	Severities ValueFilter `mapstructure:"severities"`
 	Status     ValueFilter `mapstructure:"status"`
 	Sources    ValueFilter `mapstructure:"sources"`
+	Kinds      ValueFilter `mapstructure:"kinds"`
 }
 
 type TargetBaseOptions struct {

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -260,6 +260,7 @@ func (r *Resolver) RegisterMetricsListener() {
 			ToRuleSet(r.config.Metrics.Filter.Policies),
 			ToRuleSet(r.config.Metrics.Filter.Sources),
 			ToRuleSet(r.config.Metrics.Filter.Severities),
+			ToRuleSet(r.config.Metrics.Filter.Kinds),
 		),
 		metrics.NewReportFilter(
 			ToRuleSet(r.config.Metrics.Filter.Namespaces),

--- a/pkg/listener/metrics/cluster_result_detailed_test.go
+++ b/pkg/listener/metrics/cluster_result_detailed_test.go
@@ -37,7 +37,7 @@ func Test_DetailedClusterResultMetricGeneration(t *testing.T) {
 		Results: []v1alpha2.PolicyReportResult{fixtures.FailResult, fixtures.FailDisallowRuleResult},
 	}
 
-	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{})
+	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{}, (validate.RuleSets{}))
 	handler := metrics.CreateDetailedClusterResultMetricListener(filter, gauge)
 
 	t.Run("Added Metric", func(t *testing.T) {

--- a/pkg/listener/metrics/filter.go
+++ b/pkg/listener/metrics/filter.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/validate"
 )
 
-func NewResultFilter(namespace, status, policy, source, severity validate.RuleSets) *report.ResultFilter {
+func NewResultFilter(namespace, status, policy, source, severity, kind validate.RuleSets) *report.ResultFilter {
 	f := &report.ResultFilter{}
 	if namespace.Count() > 0 {
 		f.AddValidation(func(r v1alpha2.PolicyReportResult) bool {
@@ -39,6 +39,16 @@ func NewResultFilter(namespace, status, policy, source, severity validate.RuleSe
 	if severity.Count() > 0 {
 		f.AddValidation(func(r v1alpha2.PolicyReportResult) bool {
 			return validate.MatchRuleSet(string(r.Severity), severity)
+		})
+	}
+
+	if kind.Count() > 0 {
+		f.AddValidation(func(r v1alpha2.PolicyReportResult) bool {
+			if !r.HasResource() {
+				return true
+			}
+
+			return validate.Kind(r.GetResource().Kind, kind)
 		})
 	}
 

--- a/pkg/listener/metrics/filter_test.go
+++ b/pkg/listener/metrics/filter_test.go
@@ -11,62 +11,62 @@ import (
 
 func Test_Vaildate(t *testing.T) {
 	t.Run("Allow ClusterReport", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if !filter.Validate(fixtures.PassNamespaceResult) {
 			t.Error("Expected Validate returns true if Report is a ClusterPolicyReport without namespace")
 		}
 	})
 	t.Run("Disallow if Report include not match", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"dev"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"dev"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns false if Report namespace not match include rule")
 		}
 	})
 
 	t.Run("Allow Report with matching include Namespace", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if !filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns true if Report namespace matches include pattern")
 		}
 	})
 
 	t.Run("Disallow Report with matching exclude Namespace", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{Exclude: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{Exclude: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns false if Report namespace matches exclude pattern")
 		}
 	})
 
 	t.Run("Ignores exclude pattern if include namespaces provided", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{Exclude: []string{"test"}, Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{Exclude: []string{"test"}, Include: []string{"test"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if !filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns true because exclude patterns ignored if include patterns provided")
 		}
 	})
 
 	t.Run("Disallow Report with matching exclude Policy", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"require-requests-*"}}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"require-requests-*"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns false if Report policy matches exclude pattern")
 		}
 	})
 
 	t.Run("Disallow Report with matching exclude Status", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{Exclude: []string{v1alpha2.StatusFail}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{Exclude: []string{v1alpha2.StatusFail}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns false if Report status matches exclude pattern")
 		}
 	})
 
 	t.Run("Disallow Report with matching exclude Severity", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{v1alpha2.SeverityHigh}})
+		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{v1alpha2.SeverityHigh}}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailResult) {
 			t.Error("Expected Validate returns false if Report severity matches exclude pattern")
 		}
 	})
 
 	t.Run("Disallow Report with matching exclude Source", func(t *testing.T) {
-		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"Kyverno"}}, validate.RuleSets{})
+		filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"Kyverno"}}, validate.RuleSets{}, validate.RuleSets{})
 		if filter.Validate(fixtures.FailPodResult) {
 			t.Error("Expected Validate returns false if Report source matches exclude pattern")
 		}

--- a/pkg/listener/metrics/result_custom_test.go
+++ b/pkg/listener/metrics/result_custom_test.go
@@ -41,7 +41,7 @@ func Test_CustomResultMetricGeneration(t *testing.T) {
 		Results: []v1alpha2.PolicyReportResult{fixtures.FailResult, fixtures.FailPodResult, fixtures.FailDisallowRuleResult},
 	}
 
-	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{})
+	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 
 	t.Run("Added Metric", func(t *testing.T) {
 		handler := metrics.CreateCustomResultMetricsListener(filter, gauge, metrics.CreateLabelGenerator([]string{"namespace", "policy", "status", "source", "label:app", "property:xyz"}, []string{"namespace", "policy", "status", "source", "app", "xyz"}))

--- a/pkg/listener/metrics/result_detailed_test.go
+++ b/pkg/listener/metrics/result_detailed_test.go
@@ -39,7 +39,7 @@ func Test_DetailedResultMetricGeneration(t *testing.T) {
 		Results: []v1alpha2.PolicyReportResult{fixtures.PassResult, fixtures.FailDisallowRuleResult},
 	}
 
-	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{})
+	filter := metrics.NewResultFilter(validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{Exclude: []string{"disallow-policy"}}, validate.RuleSets{}, validate.RuleSets{}, validate.RuleSets{})
 	handler := metrics.CreateDetailedResultMetricListener(filter, gauge)
 
 	t.Run("Added Metric", func(t *testing.T) {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -14,6 +14,14 @@ func Namespace(namespace string, namespaces RuleSets) bool {
 	return MatchRuleSet(namespace, namespaces)
 }
 
+func Kind(kind string, kinds RuleSets) bool {
+	if kind == "" {
+		return true
+	}
+
+	return MatchRuleSet(kind, kinds)
+}
+
 func MatchRuleSet(value string, rules RuleSets) bool {
 	if len(rules.Include) > 0 {
 		for _, ns := range rules.Include {


### PR DESCRIPTION
Hey. This Pull request adds new attribute `kind` in the Metrics filter. Please review and release **as soon as possible** because **we are heavily blocked by this**. 

We have huge metrics and we want to keep the metrics in the backend. But for metrics endpoint, we want to filter based on specific Kind of the resource. 

Related MR for docs can be seen [here](https://github.com/kyverno/policy-reporter-docs/pull/17)

Thanks in advance :) 