### PR TITLE
Fix violations "email sent to" log

### DIFF
--- a/cmd/send/violations.go
+++ b/cmd/send/violations.go
@@ -75,7 +75,7 @@ func NewViolationsCMD() *cobra.Command {
 					return
 				}
 
-				logger.Sugar().Infof("email sent to %s\n", strings.Join(c.EmailReports.Summary.To, ", "))
+				logger.Sugar().Infof("email sent to %s\n", strings.Join(c.EmailReports.Violations.To, ", "))
 			}()
 
 			for _, ch := range c.EmailReports.Violations.Channels {


### PR DESCRIPTION
The violations command was logging the summary recipients.

This PR fixes it by logging the correct config entry.