### PR TITLE
SecurityHub: fix product name field and allow to set company name

### DIFF
--- a/charts/policy-reporter/config.yaml
+++ b/charts/policy-reporter/config.yaml
@@ -301,6 +301,7 @@ securityHub:
   secretRef: {{ .Values.target.securityHub.secretRef | quote }}
   mountedSecret: {{ .Values.target.securityHub.mountedSecret | quote }}
   productName: {{ .Values.target.securityHub.productName | quote }}
+  companyName:  {{ .Values.target.securityHub.companyName | quote }}
   region: {{ .Values.target.securityHub.region }}
   endpoint: {{ .Values.target.securityHub.endpoint }}
   minimumPriority: {{ .Values.target.securityHub.minimumPriority | quote }}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,6 +208,7 @@ type SecurityHub struct {
 	AWSConfig         `mapstructure:",squash"`
 	AccountID         string         `mapstructure:"accountId"`
 	ProductName       string         `mapstructure:"productName"`
+	CompanyName       string         `mapstructure:"companyName"`
 	DelayInSeconds    int            `mapstructure:"delayInSeconds"`
 	Cleanup           bool           `mapstructure:"cleanup"`
 	Channels          []*SecurityHub `mapstructure:"channels"`

--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -726,6 +726,7 @@ func (f *TargetFactory) createSecurityHub(config, parent *SecurityHub) target.Cl
 	sugar.Infof("%s configured", config.Name)
 
 	setFallback(&config.ProductName, parent.ProductName, "Policy Reporter")
+	setFallback(&config.CompanyName, parent.CompanyName, "Kyverno")
 	setInt(&config.DelayInSeconds, parent.DelayInSeconds)
 
 	return securityhub.NewClient(securityhub.Options{
@@ -735,6 +736,7 @@ func (f *TargetFactory) createSecurityHub(config, parent *SecurityHub) target.Cl
 		AccountID:     config.AccountID,
 		Region:        config.Region,
 		ProductName:   config.ProductName,
+		CompanyName:   config.CompanyName,
 		Delay:         time.Duration(config.DelayInSeconds) * time.Second,
 	})
 }

--- a/pkg/target/securityhub/securityhub.go
+++ b/pkg/target/securityhub/securityhub.go
@@ -18,7 +18,7 @@ type HubClient interface {
 	GetFindings(ctx context.Context, params *hub.GetFindingsInput, optFns ...func(*hub.Options)) (*hub.GetFindingsOutput, error)
 }
 
-// Options to configure the S3 target
+// Options to configure the SecurityHub target
 type Options struct {
 	target.ClientOptions
 	CustomFields map[string]string
@@ -26,6 +26,7 @@ type Options struct {
 	AccountID    string
 	Region       string
 	ProductName  string
+	CompanyName  string
 	Delay        time.Duration
 	Cleanup      bool
 }
@@ -37,6 +38,7 @@ type client struct {
 	accountID    string
 	region       string
 	productName  string
+	companyName  string
 	delay        time.Duration
 	cleanup      bool
 }
@@ -75,9 +77,8 @@ func (c *client) Send(result v1alpha2.PolicyReportResult) {
 				},
 				Title:       &title,
 				Description: &result.Message,
-				ProductFields: map[string]string{
-					"Product Name": c.productName,
-				},
+				ProductName: &c.productName,
+				CompanyName: &c.companyName,
 				Compliance: &types.Compliance{
 					Status: types.ComplianceStatusFailed,
 				},
@@ -229,7 +230,7 @@ func (c *client) mapOtherDetails(result v1alpha2.PolicyReportResult) map[string]
 	return details
 }
 
-// NewClient creates a new S3.client to send Results to S3.
+// NewClient creates a new SecurityHub.client to send Results to SecurityHub.
 func NewClient(options Options) target.Client {
 	return &client{
 		target.NewBaseClient(options.ClientOptions),
@@ -238,6 +239,7 @@ func NewClient(options Options) target.Client {
 		options.AccountID,
 		options.Region,
 		options.ProductName,
+		options.CompanyName,
 		options.Delay,
 		options.Cleanup,
 	}

--- a/pkg/target/securityhub/securityhub_test.go
+++ b/pkg/target/securityhub/securityhub_test.go
@@ -46,6 +46,7 @@ func TestSecurityHub(t *testing.T) {
 			AccountID:   "accountID",
 			Region:      "eu-central-1",
 			ProductName: "Policy Reporter",
+			CompanyName: "Kyverno",
 			Client: &client{
 				send: func(findings []types.AwsSecurityFinding) {
 					if len(findings) != 1 {
@@ -64,8 +65,11 @@ func TestSecurityHub(t *testing.T) {
 					if *finding.ProductArn != "arn:aws:securityhub:eu-central-1:accountID:product/accountID/default" {
 						t.Errorf("unexpected product arn: %s", *finding.ProductArn)
 					}
-					if finding.ProductFields["Product Name"] != "Policy Reporter" {
-						t.Errorf("unexpected product name arn: %s", finding.ProductFields["Product Name"])
+					if *finding.ProductName != "Policy Reporter" {
+						t.Errorf("unexpected product name: %s", *finding.ProductName)
+					}
+					if *finding.CompanyName != "Kyverno" {
+						t.Errorf("unexpected company name: %s", *finding.CompanyName)
 					}
 				},
 			},
@@ -80,6 +84,7 @@ func TestSecurityHub(t *testing.T) {
 			AccountID:   "accountID",
 			Region:      "eu-central-1",
 			ProductName: "Policy Reporter",
+			CompanyName: "Kyverno",
 			Client:      h,
 			Cleanup:     false,
 		})
@@ -100,6 +105,7 @@ func TestSecurityHub(t *testing.T) {
 			AccountID:   "accountID",
 			Region:      "eu-central-1",
 			ProductName: "Policy Reporter",
+			CompanyName: "Kyverno",
 			Client:      h,
 			Cleanup:     true,
 		})
@@ -126,6 +132,7 @@ func TestSecurityHub(t *testing.T) {
 			AccountID:   "accountID",
 			Region:      "eu-central-1",
 			ProductName: "Policy Reporter",
+			CompanyName: "Kyverno",
 			Client:      h,
 			Cleanup:     true,
 		})
@@ -152,6 +159,7 @@ func TestSecurityHub(t *testing.T) {
 			AccountID:   "accountID",
 			Region:      "eu-central-1",
 			ProductName: "Policy Reporter",
+			CompanyName: "Kyverno",
 			Client:      h,
 			Cleanup:     true,
 		})


### PR DESCRIPTION
This PR tries to do 2 things. Both related to better identify Policy Reporter created findings in SecurityHub.

1. Update `productName` that it is now populated within `ProductName` field. Otherwise AWS auto fills `Default`.
2. Add option to specify Company name in findings using `companyName` config option. Otherwise AWS auto fills `Personal`.