### PR TITLE
docs: point to ui subchart's values.yaml

### DIFF
--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -170,7 +170,7 @@ sourceConfig: {}
 #     enabled: true
 #     fields: ["resource", "policy", "rule", "category", "result", "message"]
 
-# enable policy-report-ui
+# Settings for the Policy Reporter UI subchart (see subchart's values.yaml)
 ui:
   enabled: false
 


### PR DESCRIPTION
Although obvious to some, it might help others to mention that the `ui` section has more supported values than just `ui.enabled` and where to look for them.