### PR TITLE
Use internal AWS credential loading as fallback

### DIFF
--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -926,13 +926,13 @@ func NewTargetFactory(secretClient secrets.Client) *TargetFactory {
 }
 
 func hasAWSIdentity() bool {
-	irsa_arn := os.Getenv("AWS_ROLE_ARN")
-	irsa_file := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	irsaARN := os.Getenv("AWS_ROLE_ARN")
+	irsaFile := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
 
-	pod_identity_file := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
-	pod_identity_uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+	podIdentityFile := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
+	podIdentityURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
 
-	return (irsa_arn != "" && irsa_file != "") || (pod_identity_file != "" && pod_identity_uri != "")
+	return (irsaARN != "" && irsaFile != "") || (podIdentityFile != "" && podIdentityURI != "")
 }
 
 func checkAWSConfig(name string, config AWSConfig, parent AWSConfig) error {

--- a/pkg/helper/aws.go
+++ b/pkg/helper/aws.go
@@ -3,13 +3,13 @@ package helper
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -164,11 +164,8 @@ func createConfig(accessKeyID, secretAccessKey, region string) (aws.Config, erro
 	} else if webIdentity != "" && roleARN != "" {
 		zap.L().Debug("configure AWS credentals provider", zap.String("provider", "WebIdentityRoleProvider"), zap.String("WebIdentidyFile", webIdentity))
 		cfg.Credentials = stscreds.NewWebIdentityRoleProvider(sts.NewFromConfig(cfg), roleARN, stscreds.IdentityTokenFile(webIdentity))
-	} else if roleARN != "" {
-		zap.L().Debug("configure AWS credentals provider", zap.String("provider", "AssumeRoleProvider"))
-		cfg.Credentials = stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), roleARN)
 	} else {
-		cfg.Credentials = ec2rolecreds.New()
+		zap.L().Debug("used AWS credentials provider", zap.String("provider", fmt.Sprintf("%T", cfg.Credentials)))
 	}
 
 	return cfg, nil


### PR DESCRIPTION
@balonik this change should enable AWS to fallback to its internal credentials load logic when no static credentials nor web identity is used.