### PR TITLE
FIX: Propagate Slack channel Override

### DIFF
--- a/pkg/target/slack/slack.go
+++ b/pkg/target/slack/slack.go
@@ -66,6 +66,10 @@ func (s *client) newPayload(result v1alpha2.PolicyReportResult) payload {
 		Attachments: make([]attachment, 0, 1),
 	}
 
+	if s.channel != "" {
+		p.Channel = s.channel
+	}
+
 	att := attachment{
 		Color:  colors[result.Priority],
 		Blocks: make([]block, 0),


### PR DESCRIPTION
This PR fixes a bug that prevents routing slack messages to the configured target channels.

Related to: https://github.com/kyverno/policy-reporter/issues/458

Testing done:

Config file:

````
slack:
  channels:
    - channel: kyverno-reports1
      customFields:
        cluster: TestCluster
      filter:
        namespaces:
          include:
          - team1-a
          - team1-b
        policies:
          include:
          - test-policy
        priorities:
          include: warning
      name: team1
      skipExistingOnStartup: false
      sources:
      - kyverno
      webhook: https://slack.webhook
    - channel: kyverno-reports2
      customFields:
        cluster: TestCluster
      filter:
        namespaces:
          include:
            - team2-a
        policies:
          include:
          - test-policy
        priorities:
          include: warning
      name: team2
      skipExistingOnStartup: false
      sources:
      - kyverno
      webhook: https://same-slack-webhook-as-team1

````

Output
````
{"L":"INFO","T":"2024-07-09 16:12:34","C":"config/resolver.go:87","M":"API BasicAuth enabled"}
{"L":"INFO","T":"2024-07-09 16:12:34","C":"config/target_factory.go:351","M":"team1 configured"}
{"L":"INFO","T":"2024-07-09 16:12:34","C":"config/target_factory.go:351","M":"team2 configured"}
{"L":"INFO","T":"2024-07-09 16:12:34","C":"cmd/run.go:152","M":"start client","worker":5}
{"L":"INFO","T":"2024-07-09 16:12:35","C":"kubernetes/policy_report_client.go:63","M":"informer sync completed"}
{"L":"INFO","T":"2024-07-09 16:12:35","C":"http/utils.go:51","M":"team1: PUSH OK"}
{"L":"INFO","T":"2024-07-09 16:12:35","C":"http/utils.go:51","M":"team2: PUSH OK"}
{"L":"INFO","T":"2024-07-09 16:12:35","C":"http/utils.go:51","M":"team2: PUSH OK"}

````

Slack messages are routed properly