### PR TITLE
FIX: Slack channel override when using a secretRef for the webhook

### DIFF
--- a/pkg/config/target_factory.go
+++ b/pkg/config/target_factory.go
@@ -815,6 +815,8 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 	case *Slack:
 		if values.Webhook != "" {
 			c.Webhook = values.Webhook
+		}
+		if values.Channel != "" {
 			c.Channel = values.Channel
 		}
 


### PR DESCRIPTION
Related to: https://github.com/kyverno/policy-reporter/issues/458

Config file:

````
namespace: kyverno
slack:
  channels:
    - channel: kyverno-reports1
      customFields:
        cluster: ACluster
      filter:
        namespaces:
          include:
          - foo
          - bar
        policies:
          include:
          - testpolicy
        priorities:
          include: warning
      name: team1
      secretRef: kyverno-policy-reporter-data
      skipExistingOnStartup: false
      sources:
      - kyverno
    - channel: kyverno-reports2
      customFields:
        cluster: ACluster
      filter:
        namespaces:
          include:
          - tes1
        policies:
          include:
          - testPolicy
        priorities:
          include: warning
      name: team2
      secretRef: kyverno-policy-reporter-data
      skipExistingOnStartup: false
      sources:
      - kyverno

````
output

````
1.7207403643162174e+09	info	API BasicAuth enabled
1.7207403643356915e+09	info	team1 configured
1.7207403643685389e+09	info	team2 configured
1.7207403643687537e+09	info	start client	{"worker": 5}
1.7207403644691234e+09	info	informer sync completed
1.7207403647018857e+09	info	team1: PUSH OK
1.7207403647848663e+09	info	team2: PUSH OK
1.720740364784887e+09	info	team2: PUSH OK
````
