### PR TITLE
ADD: json tags to the configuration structure

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,41 +3,41 @@ package config
 import "github.com/kyverno/policy-reporter/pkg/target"
 
 type ValueFilter struct {
-	Include []string `mapstructure:"include"`
-	Exclude []string `mapstructure:"exclude"`
+	Include []string `mapstructure:"include" json:"include,omitempty"`
+	Exclude []string `mapstructure:"exclude" json:"exclude,omitempty"`
 }
 
 type EmailReportFilter struct {
-	DisableClusterReports bool        `mapstructure:"disableClusterReports"`
-	Namespaces            ValueFilter `mapstructure:"namespaces"`
-	Sources               ValueFilter `mapstructure:"sources"`
+	DisableClusterReports bool        `mapstructure:"disableClusterReports" json: "disableClusterReports,omitempty"`
+	Namespaces            ValueFilter `mapstructure:"namespaces" json:"namespaces,omitempty"`
+	Sources               ValueFilter `mapstructure:"sources" json:"sources,omitempty"`
 }
 
 type TargetFilter struct {
-	Namespaces   ValueFilter `mapstructure:"namespaces"`
-	Priorities   ValueFilter `mapstructure:"priorities"`
-	Policies     ValueFilter `mapstructure:"policies"`
-	ReportLabels ValueFilter `mapstructure:"reportLabels"`
+	Namespaces   ValueFilter `mapstructure:"namespaces" json:"namespaces,omitempty"`
+	Priorities   ValueFilter `mapstructure:"priorities" json:"priorities,omitempty"`
+	Policies     ValueFilter `mapstructure:"policies" json:"policies,omitempty"`
+	ReportLabels ValueFilter `mapstructure:"reportLabels" json:"reportLabels,omitempty"`
 }
 
 type MetricsFilter struct {
-	Namespaces ValueFilter `mapstructure:"namespaces"`
-	Policies   ValueFilter `mapstructure:"policies"`
-	Severities ValueFilter `mapstructure:"severities"`
-	Status     ValueFilter `mapstructure:"status"`
-	Sources    ValueFilter `mapstructure:"sources"`
-	Kinds      ValueFilter `mapstructure:"kinds"`
+	Namespaces ValueFilter `mapstructure:"namespaces" json:"namespaces,omitempty"`
+	Policies   ValueFilter `mapstructure:"policies" json:"policies,omitempty"`
+	Severities ValueFilter `mapstructure:"severities" json:"severities,omitempty"`
+	Status     ValueFilter `mapstructure:"status" json:"status,omitempty"`
+	Sources    ValueFilter `mapstructure:"sources" json:"sources,omitempty"`
+	Kinds      ValueFilter `mapstructure:"kinds" json: "kinds,omitempty"`
 }
 
 type TargetBaseOptions struct {
-	Name            string            `mapstructure:"name"`
-	MinimumPriority string            `mapstructure:"minimumPriority"`
-	Filter          TargetFilter      `mapstructure:"filter"`
-	SecretRef       string            `mapstructure:"secretRef"`
-	MountedSecret   string            `mapstructure:"mountedSecret"`
-	Sources         []string          `mapstructure:"sources"`
-	CustomFields    map[string]string `mapstructure:"customFields"`
-	SkipExisting    bool              `mapstructure:"skipExistingOnStartup"`
+	Name            string            `mapstructure:"name" json:"name,omitempty"`
+	MinimumPriority string            `mapstructure:"minimumPriority" json: "minimumPriority,omitempty"`
+	Filter          TargetFilter      `mapstructure:"filter" json: "filter,omitempty"`
+	SecretRef       string            `mapstructure:"secretRef" json: "secretRef,omitempty"`
+	MountedSecret   string            `mapstructure:"mountedSecret" json: "mountedSecret,omitempty"`
+	Sources         []string          `mapstructure:"sources" json: "sources,omitempty"`
+	CustomFields    map[string]string `mapstructure:"customFields" json: "customFields,omitempty"`
+	SkipExisting    bool              `mapstructure:"skipExistingOnStartup", json: "skipExistingOnStartup,omitempty"`
 }
 
 func (config *TargetBaseOptions) MapBaseParent(parent TargetBaseOptions) {
@@ -60,10 +60,10 @@ func (config *TargetBaseOptions) ClientOptions() target.ClientOptions {
 }
 
 type AWSConfig struct {
-	AccessKeyID     string `mapstructure:"accessKeyID"`
-	SecretAccessKey string `mapstructure:"secretAccessKey"`
-	Region          string `mapstructure:"region"`
-	Endpoint        string `mapstructure:"endpoint"`
+	AccessKeyID     string `mapstructure:"accessKeyID" json: "accessKeyID,omitempty"`
+	SecretAccessKey string `mapstructure:"secretAccessKey" json: "secretAccessKey,omitempty"`
+	Region          string `mapstructure:"region" json: "region,omitempty"`
+	Endpoint        string `mapstructure:"endpoint" json: "endpoint,omitempty"`
 }
 
 func (config *AWSConfig) MapAWSParent(parent AWSConfig) {
@@ -90,78 +90,78 @@ type TargetOption interface {
 
 // Loki configuration
 type Loki struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	CustomLabels      map[string]string `mapstructure:"customLabels"`
-	Headers           map[string]string `mapstructure:"headers"`
-	Host              string            `mapstructure:"host"`
-	SkipTLS           bool              `mapstructure:"skipTLS"`
-	Certificate       string            `mapstructure:"certificate"`
-	Path              string            `mapstructure:"path"`
-	Channels          []*Loki           `mapstructure:"channels"`
-	Username          string            `mapstructure:"username"`
-	Password          string            `mapstructure:"password"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	CustomLabels      map[string]string `mapstructure:"customLabels" json:"customLabels,omitempty"`
+	Headers           map[string]string `mapstructure:"headers" json:"headers,omitempty"`
+	Host              string            `mapstructure:"host" json:"host,omitempty"`
+	SkipTLS           bool              `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string            `mapstructure:"certificate" json:"certificate,omitempty"`
+	Path              string            `mapstructure:"path" json:"path,omitempty"`
+	Channels          []*Loki           `mapstructure:"channels" json:"channels,omitempty"`
+	Username          string            `mapstructure:"username" json:"username,omitempty"`
+	Password          string            `mapstructure:"password" json:"password,omitempty"`
 }
 
 // Elasticsearch configuration
 type Elasticsearch struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Host              string           `mapstructure:"host"`
-	SkipTLS           bool             `mapstructure:"skipTLS"`
-	Certificate       string           `mapstructure:"certificate"`
-	Index             string           `mapstructure:"index"`
-	Rotation          string           `mapstructure:"rotation"`
-	Username          string           `mapstructure:"username"`
-	Password          string           `mapstructure:"password"`
-	APIKey            string           `mapstructure:"apiKey"`
-	Channels          []*Elasticsearch `mapstructure:"channels"`
-	TypelessAPI       bool             `mapstructure:"typelessApi"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Host              string           `mapstructure:"host" json:"host,omitempty"`
+	SkipTLS           bool             `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string           `mapstructure:"certificate" json:"certificate,omitempty"`
+	Index             string           `mapstructure:"index" json:"index,omitempty"`
+	Rotation          string           `mapstructure:"rotation" json:"rotation,omitempty"`
+	Username          string           `mapstructure:"username" json:"username,omitempty"`
+	Password          string           `mapstructure:"password" json:"password,omitempty"`
+	APIKey            string           `mapstructure:"apiKey" json:"apiKey,omitempty"`
+	Channels          []*Elasticsearch `mapstructure:"channels" json:"channels,omitempty"`
+	TypelessAPI       bool             `mapstructure:"typelessApi" json:"typelessApi,omitempty"`
 }
 
 // Slack configuration
 type Slack struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Webhook           string   `mapstructure:"webhook"`
-	Channel           string   `mapstructure:"channel"`
-	Channels          []*Slack `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Webhook           string   `mapstructure:"webhook" json:"webhook,omitempty"`
+	Channel           string   `mapstructure:"channel" json:"channel,omitempty"`
+	Channels          []*Slack `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // Discord configuration
 type Discord struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Webhook           string     `mapstructure:"webhook"`
-	Channels          []*Discord `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Webhook           string     `mapstructure:"webhook" json:"webhook,omitempty"`
+	Channels          []*Discord `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // Teams configuration
 type Teams struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Webhook           string   `mapstructure:"webhook"`
-	SkipTLS           bool     `mapstructure:"skipTLS"`
-	Certificate       string   `mapstructure:"certificate"`
-	Channels          []*Teams `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Webhook           string   `mapstructure:"webhook" json:"webhook,omitempty"`
+	SkipTLS           bool     `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string   `mapstructure:"certificate" json:"certificate,omitempty"`
+	Channels          []*Teams `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // UI configuration
 type UI struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Host              string `mapstructure:"host"`
-	SkipTLS           bool   `mapstructure:"skipTLS"`
-	Certificate       string `mapstructure:"certificate"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Host              string `mapstructure:"host" json:"host,omitempty"`
+	SkipTLS           bool   `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string `mapstructure:"certificate" json:"certificate,omitempty"`
 }
 
 // Webhook configuration
 type Webhook struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Host              string            `mapstructure:"host"`
-	SkipTLS           bool              `mapstructure:"skipTLS"`
-	Certificate       string            `mapstructure:"certificate"`
-	Headers           map[string]string `mapstructure:"headers"`
-	Channels          []*Webhook        `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Host              string            `mapstructure:"host" json:"host,omitempty"`
+	SkipTLS           bool              `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string            `mapstructure:"certificate" json:"certificate,omitempty"`
+	Headers           map[string]string `mapstructure:"headers" json:"headers,omitempty"`
+	Channels          []*Webhook        `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // Telegram configuration
 type Telegram struct {
-	TargetBaseOptions `mapstructure:",squash"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
 	Host              string            `mapstructure:"host"`
 	Token             string            `mapstructure:"token"`
 	ChatID            string            `mapstructure:"chatID"`
@@ -173,108 +173,108 @@ type Telegram struct {
 
 // GoogleChat configuration
 type GoogleChat struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Webhook           string            `mapstructure:"webhook"`
-	SkipTLS           bool              `mapstructure:"skipTLS"`
-	Certificate       string            `mapstructure:"certificate"`
-	Headers           map[string]string `mapstructure:"headers"`
-	Channels          []*GoogleChat     `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Webhook           string            `mapstructure:"webhook" json:"webhook,omitempty"`
+	SkipTLS           bool              `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate       string            `mapstructure:"certificate" json:"certificate,omitempty"`
+	Headers           map[string]string `mapstructure:"headers" json:"headers,omitempty"`
+	Channels          []*GoogleChat     `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // S3 configuration
 type S3 struct {
-	TargetBaseOptions    `mapstructure:",squash"`
-	AWSConfig            `mapstructure:",squash"`
-	Prefix               string `mapstructure:"prefix"`
-	Bucket               string `mapstructure:"bucket"`
-	BucketKeyEnabled     bool   `mapstructure:"bucketKeyEnabled"`
-	KmsKeyID             string `mapstructure:"kmsKeyId"`
-	ServerSideEncryption string `mapstructure:"serverSideEncryption"`
-	PathStyle            bool   `mapstructure:"pathStyle"`
-	Channels             []*S3  `mapstructure:"channels"`
+	TargetBaseOptions    `mapstructure:",squash" json:",inline"`
+	AWSConfig            `mapstructure:",squash" json:",inline"`
+	Prefix               string `mapstructure:"prefix" json:"prefix,omitempty"`
+	Bucket               string `mapstructure:"bucket" json:"bucket,omitempty"`
+	BucketKeyEnabled     bool   `mapstructure:"bucketKeyEnabled" json:"bucketKeyEnabled,omitempty"`
+	KmsKeyID             string `mapstructure:"kmsKeyId" json:"kmsKeyId,omitempty"`
+	ServerSideEncryption string `mapstructure:"serverSideEncryption" json:"serverSideEncryption,omitempty"`
+	PathStyle            bool   `mapstructure:"pathStyle" json:"pathStyle,omitempty"`
+	Channels             []*S3  `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // Kinesis configuration
 type Kinesis struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	AWSConfig         `mapstructure:",squash"`
-	StreamName        string     `mapstructure:"streamName"`
-	Channels          []*Kinesis `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	AWSConfig         `mapstructure:",squash" json:",inline"`
+	StreamName        string     `mapstructure:"streamName" json:"streamName,omitempty"`
+	Channels          []*Kinesis `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // SecurityHub configuration
 type SecurityHub struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	AWSConfig         `mapstructure:",squash"`
-	AccountID         string         `mapstructure:"accountId"`
-	ProductName       string         `mapstructure:"productName"`
-	CompanyName       string         `mapstructure:"companyName"`
-	DelayInSeconds    int            `mapstructure:"delayInSeconds"`
-	Cleanup           bool           `mapstructure:"cleanup"`
-	Channels          []*SecurityHub `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	AWSConfig         `mapstructure:",squash" json:",inline"`
+	AccountID         string         `mapstructure:"accountId" json:"accountId,omitempty"`
+	ProductName       string         `mapstructure:"productName" json:"productName,omitempty"`
+	CompanyName       string         `mapstructure:"companyName" json:"companyName,omitempty"`
+	DelayInSeconds    int            `mapstructure:"delayInSeconds" json:"delayInSeconds,omitempty"`
+	Cleanup           bool           `mapstructure:"cleanup" json:"cleanup,omitempty"`
+	Channels          []*SecurityHub `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // GCS configuration
 type GCS struct {
-	TargetBaseOptions `mapstructure:",squash"`
-	Credentials       string   `mapstructure:"credentials"`
-	Prefix            string   `mapstructure:"prefix"`
-	Bucket            string   `mapstructure:"bucket"`
-	Sources           []string `mapstructure:"sources"`
-	Channels          []*GCS   `mapstructure:"channels"`
+	TargetBaseOptions `mapstructure:",squash" json:",inline"`
+	Credentials       string   `mapstructure:"credentials" json:"customLabels,omitempty"`
+	Prefix            string   `mapstructure:"prefix" json:"credentials,omitempty"`
+	Bucket            string   `mapstructure:"bucket" json:"bucket,omitempty"`
+	Sources           []string `mapstructure:"sources" json:"sources,omitempty"`
+	Channels          []*GCS   `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // SMTP configuration
 type SMTP struct {
-	Host        string `mapstructure:"host"`
-	Port        int    `mapstructure:"port"`
-	Username    string `mapstructure:"username"`
-	Password    string `mapstructure:"password"`
-	From        string `mapstructure:"from"`
-	Encryption  string `mapstructure:"encryption"`
-	SkipTLS     bool   `mapstructure:"skipTLS"`
-	Certificate string `mapstructure:"certificate"`
+	Host        string `mapstructure:"host" json:"host,omitempty"`
+	Port        int    `mapstructure:"port" json:"port,omitempty"`
+	Username    string `mapstructure:"username" json:"username,omitempty"`
+	Password    string `mapstructure:"password" json:"password,omitempty"`
+	From        string `mapstructure:"from" json:"from,omitempty"`
+	Encryption  string `mapstructure:"encryption" json:"encryption,omitempty"`
+	SkipTLS     bool   `mapstructure:"skipTLS" json:"skipTLS,omitempty"`
+	Certificate string `mapstructure:"certificate" json:"certificate,omitempty"`
 }
 
 // EmailReport configuration
 type EmailReport struct {
-	To       []string          `mapstructure:"to"`
-	Format   string            `mapstructure:"format"`
-	Filter   EmailReportFilter `mapstructure:"filter"`
-	Channels []EmailReport     `mapstructure:"channels"`
+	To       []string          `mapstructure:"to" json:"to,omitempty"`
+	Format   string            `mapstructure:"format" json:"format,omitempty"`
+	Filter   EmailReportFilter `mapstructure:"filter" json:"filter,omitempty"`
+	Channels []EmailReport     `mapstructure:"channels" json:"channels,omitempty"`
 }
 
 // EmailReport configuration
 type Templates struct {
-	Dir string `mapstructure:"dir"`
+	Dir string `mapstructure:"dir" json:"dir,omitempty"`
 }
 
 // EmailReports configuration
 type EmailReports struct {
-	SMTP        SMTP        `mapstructure:"smtp"`
-	Summary     EmailReport `mapstructure:"summary"`
-	Violations  EmailReport `mapstructure:"violations"`
-	ClusterName string      `mapstructure:"clusterName"`
-	TitlePrefix string      `mapstructure:"titlePrefix"`
+	SMTP        SMTP        `mapstructure:"smtp" json:"smtp,omitempty"`
+	Summary     EmailReport `mapstructure:"summary" json:"summary,omitempty"`
+	Violations  EmailReport `mapstructure:"violations" json:"violations,omitempty"`
+	ClusterName string      `mapstructure:"clusterName" json:"clusterName,omitempty"`
+	TitlePrefix string      `mapstructure:"titlePrefix" json:"titlePrefix,omitempty"`
 }
 
 // BasicAuth configuration
 type BasicAuth struct {
-	Username  string `mapstructure:"username"`
-	Password  string `mapstructure:"password"`
-	SecretRef string `mapstructure:"secretRef"`
+	Username  string `mapstructure:"username" json:"username,omitempty"`
+	Password  string `mapstructure:"password" json:"password,omitempty"`
+	SecretRef string `mapstructure:"secretRef" json:"secretRef,omitempty"`
 }
 
 // API configuration
 type API struct {
-	Port      int       `mapstructure:"port"`
-	Logging   bool      `mapstructure:"logging"`
-	BasicAuth BasicAuth `mapstructure:"basicAuth"`
+	Port      int       `mapstructure:"port" json:"port,omitempty"`
+	Logging   bool      `mapstructure:"logging" json:"logging,omitempty"`
+	BasicAuth BasicAuth `mapstructure:"basicAuth" json:"basicAuth,omitempty"`
 }
 
 // REST configuration
 type REST struct {
-	Enabled bool `mapstructure:"enabled"`
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
 }
 
 // Metrics configuration
@@ -287,106 +287,106 @@ type Metrics struct {
 
 // Profiling configuration
 type Profiling struct {
-	Enabled bool `mapstructure:"enabled"`
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
 }
 
 // ClusterReportFilter configuration
 type ClusterReportFilter struct {
-	Disabled bool `mapstructure:"disabled"`
+	Disabled bool `mapstructure:"disabled" json:"disabled,omitempty"`
 }
 
 // ReportFilter configuration
 type ReportFilter struct {
-	Namespaces     ValueFilter         `mapstructure:"namespaces"`
-	ClusterReports ClusterReportFilter `mapstructure:"clusterReports"`
+	Namespaces     ValueFilter         `mapstructure:"namespaces" json:"namespaces,omitempty"`
+	ClusterReports ClusterReportFilter `mapstructure:"clusterReports" json:"clusterReports,omitempty"`
 }
 
 // Redis configuration
 type Redis struct {
-	Enabled  bool   `mapstructure:"enabled"`
-	Address  string `mapstructure:"address"`
-	Prefix   string `mapstructure:"prefix"`
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
-	Database int    `mapstructure:"database"`
+	Enabled  bool   `mapstructure:"enabled" json:"enabled,omitempty"`
+	Address  string `mapstructure:"address" json:"address,omitempty"`
+	Prefix   string `mapstructure:"prefix" json:"prefix,omitempty"`
+	Username string `mapstructure:"username" json:"username,omitempty"`
+	Password string `mapstructure:"password" json:"password,omitempty"`
+	Database int    `mapstructure:"database" json:"database,omitempty"`
 }
 
 // LeaderElection configuration
 type LeaderElection struct {
-	LockName        string `mapstructure:"lockName"`
-	PodName         string `mapstructure:"podName"`
-	Namespace       string `mapstructure:"namespace"`
-	LeaseDuration   int    `mapstructure:"leaseDuration"`
-	RenewDeadline   int    `mapstructure:"renewDeadline"`
-	RetryPeriod     int    `mapstructure:"retryPeriod"`
-	ReleaseOnCancel bool   `mapstructure:"releaseOnCancel"`
-	Enabled         bool   `mapstructure:"enabled"`
+	LockName        string `mapstructure:"lockName" json:"lockName,omitempty"`
+	PodName         string `mapstructure:"podName" json:"podName,omitempty"`
+	Namespace       string `mapstructure:"namespace" json:"namespace,omitempty"`
+	LeaseDuration   int    `mapstructure:"leaseDuration" json:"leaseDuration,omitempty"`
+	RenewDeadline   int    `mapstructure:"renewDeadline" json:"renewDeadline,omitempty"`
+	RetryPeriod     int    `mapstructure:"retryPeriod" json:"retryPeriod,omitempty"`
+	ReleaseOnCancel bool   `mapstructure:"releaseOnCancel" json:"releaseOnCancel,omitempty"`
+	Enabled         bool   `mapstructure:"enabled" json:"enabled,omitempty"`
 }
 
 // K8sClient config struct
 type K8sClient struct {
-	QPS        float32 `mapstructure:"qps"`
-	Burst      int     `mapstructure:"burst"`
-	Kubeconfig string  `mapstructure:"kubeconfig"`
+	QPS        float32 `mapstructure:"qps" json:"qps,omitempty"`
+	Burst      int     `mapstructure:"burst" json:"burst,omitempty"`
+	Kubeconfig string  `mapstructure:"kubeconfig" json:"kubeconfig,omitempty"`
 }
 
 type Logging struct {
-	LogLevel    int8   `mapstructure:"logLevel"`
-	Encoding    string `mapstructure:"encoding"`
-	Development bool   `mapstructure:"development"`
+	LogLevel    int8   `mapstructure:"logLevel" json:"logLevel,omitempty"`
+	Encoding    string `mapstructure:"encoding" json:"encoding,omitempty"`
+	Development bool   `mapstructure:"development" json:"development,omitempty"`
 }
 
 type Database struct {
-	Type          string `mapstructure:"type"`
-	DSN           string `mapstructure:"dsn"`
-	Username      string `mapstructure:"username"`
-	Password      string `mapstructure:"password"`
-	Database      string `mapstructure:"database"`
-	Host          string `mapstructure:"host"`
-	EnableSSL     bool   `mapstructure:"enableSSL"`
-	SecretRef     string `mapstructure:"secretRef"`
-	MountedSecret string `mapstructure:"mountedSecret"`
+	Type          string `mapstructure:"type" json:"type,omitempty"`
+	DSN           string `mapstructure:"dsn" json:"dsn,omitempty"`
+	Username      string `mapstructure:"username" json:"username,omitempty"`
+	Password      string `mapstructure:"password" json:"password,omitempty"`
+	Database      string `mapstructure:"database" json:"database,omitempty"`
+	Host          string `mapstructure:"host" json:"host,omitempty"`
+	EnableSSL     bool   `mapstructure:"enableSSL" json:"enableSSL,omitempty"`
+	SecretRef     string `mapstructure:"secretRef" json:"secretRef,omitempty"`
+	MountedSecret string `mapstructure:"mountedSecret" json:"mountedSecret,omitempty"`
 }
 
 type CustomID struct {
-	Enabled bool     `mapstructure:"enabled"`
-	Fields  []string `mapstructure:"fields"`
+	Enabled bool     `mapstructure:"enabled" json:"enabled,omitempty"`
+	Fields  []string `mapstructure:"fields" json:"fields,omitempty"`
 }
 
 type SourceConfig struct {
-	CustomID `mapstructure:"customID"`
+	CustomID `mapstructure:"customID" json:"customID,omitempty"`
 }
 
 // Config of the PolicyReporter
 type Config struct {
-	Version        string
-	Namespace      string                  `mapstructure:"namespace"`
-	Loki           *Loki                   `mapstructure:"loki"`
-	Elasticsearch  *Elasticsearch          `mapstructure:"elasticsearch"`
-	Slack          *Slack                  `mapstructure:"slack"`
-	Discord        *Discord                `mapstructure:"discord"`
-	Teams          *Teams                  `mapstructure:"teams"`
-	S3             *S3                     `mapstructure:"s3"`
-	Kinesis        *Kinesis                `mapstructure:"kinesis"`
-	SecurityHub    *SecurityHub            `mapstructure:"securityHub"`
-	GCS            *GCS                    `mapstructure:"gcs"`
-	UI             *UI                     `mapstructure:"ui"`
-	Webhook        *Webhook                `mapstructure:"webhook"`
-	Telegram       *Telegram               `mapstructure:"telegram"`
-	GoogleChat     *GoogleChat             `mapstructure:"googleChat"`
-	API            API                     `mapstructure:"api"`
-	WorkerCount    int                     `mapstructure:"worker"`
-	DBFile         string                  `mapstructure:"dbfile"`
-	Metrics        Metrics                 `mapstructure:"metrics"`
-	REST           REST                    `mapstructure:"rest"`
-	ReportFilter   ReportFilter            `mapstructure:"reportFilter"`
-	Redis          Redis                   `mapstructure:"redis"`
-	Profiling      Profiling               `mapstructure:"profiling"`
-	EmailReports   EmailReports            `mapstructure:"emailReports"`
-	LeaderElection LeaderElection          `mapstructure:"leaderElection"`
-	K8sClient      K8sClient               `mapstructure:"k8sClient"`
-	Logging        Logging                 `mapstructure:"logging"`
-	Database       Database                `mapstructure:"database"`
-	SourceConfig   map[string]SourceConfig `mapstructure:"sourceConfig"`
-	Templates      Templates               `mapstructure:"templates"`
+	Version        string                  `json:"version,omitempty"`
+	Namespace      string                  `mapstructure:"namespace" json:"namespace,omitempty"`
+	Loki           *Loki                   `mapstructure:"loki" json:"loki,omitempty"`
+	Elasticsearch  *Elasticsearch          `mapstructure:"elasticsearch" json:"elasticsearch,omitempty"`
+	Slack          *Slack                  `mapstructure:"slack" json:"slack,omitempty"`
+	Discord        *Discord                `mapstructure:"discord" json:"discord,omitempty"`
+	Teams          *Teams                  `mapstructure:"teams" json:"teams,omitempty"`
+	S3             *S3                     `mapstructure:"s3" json:"s3,omitempty"`
+	Kinesis        *Kinesis                `mapstructure:"kinesis" json:"kinesis,omitempty"`
+	SecurityHub    *SecurityHub            `mapstructure:"securityHub" json:"securityHub,omitempty"`
+	GCS            *GCS                    `mapstructure:"gcs" json:"gcs,omitempty"`
+	UI             *UI                     `mapstructure:"ui" json:"ui,omitempty"`
+	Webhook        *Webhook                `mapstructure:"webhook" json:"webhook,omitempty"`
+	Telegram       *Telegram               `mapstructure:"telegram" json:"telegram,omitempty"`
+	GoogleChat     *GoogleChat             `mapstructure:"googleChat" json:"googleChat,omitempty"`
+	API            API                     `mapstructure:"api" json:"api,omitempty"`
+	WorkerCount    int                     `mapstructure:"worker" json:"worker,omitempty"`
+	DBFile         string                  `mapstructure:"dbfile" json:"dbfile,omitempty"`
+	Metrics        Metrics                 `mapstructure:"metrics" json:"metrics,omitempty"`
+	REST           REST                    `mapstructure:"rest" json:"rest,omitempty"`
+	ReportFilter   ReportFilter            `mapstructure:"reportFilter" json:"reportFilter,omitempty"`
+	Redis          Redis                   `mapstructure:"redis" json:"redis,omitempty"`
+	Profiling      Profiling               `mapstructure:"profiling" json:"profiling,omitempty"`
+	EmailReports   EmailReports            `mapstructure:"emailReports" json:"emailReports,omitempty"`
+	LeaderElection LeaderElection          `mapstructure:"leaderElection" json:"leaderElection,omitempty"`
+	K8sClient      K8sClient               `mapstructure:"k8sClient" json:"k8sClient,omitempty"`
+	Logging        Logging                 `mapstructure:"logging" json:"logging,omitempty"`
+	Database       Database                `mapstructure:"database" json:"database,omitempty"`
+	SourceConfig   map[string]SourceConfig `mapstructure:"sourceConfig" json:"sourceConfig,omitempty"`
+	Templates      Templates               `mapstructure:"templates" json:"templates,omitempty"`
 }


### PR DESCRIPTION
The configuration structures do not have the json/yaml tags, this prevents other programs to programatically write the configuration.

The use-case is to have an external program that generates the SlackChannel configuration based of namespoaces annotations.

Viper does not have a config marshal method same with the mapstructure library.