### PR TITLE
Update service.yaml

### DIFF
--- a/charts/policy-reporter/templates/ui/service.yaml
+++ b/charts/policy-reporter/templates/ui/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: http
   {{- if .Values.ui.service.additionalPorts }}
-    {{ toYaml .Values.ui.service.additionalPorts | indent 4 }}
+    {{- toYaml .Values.ui.service.additionalPorts | nindent 4 }}
   {{- end }}
   selector:
     {{- include "ui.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
ui.service.additionalPorts causes failure in chart rendering, since no new line is added.

```    
 - port: 8080
   targetPort: http
   protocol: TCP
   name: http
     - name: authenticated
   port: 8081
   protocol: TCP
   targetPort: 8081 
```