### PR TITLE
Deployments should respect serviceAccount.autmount value in Helm chart

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -59,7 +59,7 @@ Open `http://localhost:8082/` in your browser.
 | annotations | object | `{}` | Key/value pairs that are attached to all resources. |
 | rbac.enabled | bool | `true` | Create RBAC resources |
 | serviceAccount.create | bool | `true` | Create ServiceAccount |
-| serviceAccount.automount | bool | `true` | Enable ServiceAccount automaount |
+| serviceAccount.automount | bool | `true` | Enable ServiceAccount automount |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | serviceAccount.name | string | `""` | The ServiceAccount name |
 | service.enabled | bool | `true` | Create Service |
@@ -371,7 +371,7 @@ Open `http://localhost:8082/` in your browser.
 | ui.clusters | list | `[]` | Connected Policy Reporter APIs |
 | ui.imagePullSecrets | list | `[]` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | ui.serviceAccount.create | bool | `true` | Create ServiceAccount |
-| ui.serviceAccount.automount | bool | `true` | Enable ServiceAccount automaount |
+| ui.serviceAccount.automount | bool | `true` | Enable ServiceAccount automount |
 | ui.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | ui.serviceAccount.name | string | `""` | The ServiceAccount name |
 | ui.extraManifests | list | `[]` | list of extra manifests |
@@ -431,7 +431,7 @@ Open `http://localhost:8082/` in your browser.
 | plugin.kyverno.blockReports.policyReport.annotations | list | `[]` | Annotations for all created (Cluster)PolicyReports |
 | plugin.kyverno.imagePullSecrets | list | `[]` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | plugin.kyverno.serviceAccount.create | bool | `true` | Create ServiceAccount |
-| plugin.kyverno.serviceAccount.automount | bool | `true` | Enable ServiceAccount automaount |
+| plugin.kyverno.serviceAccount.automount | bool | `true` | Enable ServiceAccount automount |
 | plugin.kyverno.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | plugin.kyverno.serviceAccount.name | string | `""` | The ServiceAccount name |
 | plugin.kyverno.podAnnotations | object | `{}` | Additional annotations to add to each pod |
@@ -488,7 +488,7 @@ Open `http://localhost:8082/` in your browser.
 | plugin.trivy.policyReporter.secretRef | string | `""` | Secret to read the API configuration from supports `host`, `certificate`, `skipTLS`, `username`, `password` key |
 | plugin.trivy.imagePullSecrets | list | `[]` | Image pull secrets for image verification policies, this will define the `--imagePullSecrets` argument |
 | plugin.trivy.serviceAccount.create | bool | `true` | Create ServiceAccount |
-| plugin.trivy.serviceAccount.automount | bool | `true` | Enable ServiceAccount automaount |
+| plugin.trivy.serviceAccount.automount | bool | `true` | Enable ServiceAccount automount |
 | plugin.trivy.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | plugin.trivy.serviceAccount.name | string | `""` | The ServiceAccount name |
 | plugin.trivy.podAnnotations | object | `{}` | Additional annotations to add to each pod |

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "policyreporter.serviceAccountName" . }}
-      automountServiceAccountToken: true
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kyverno-plugin.serviceAccountName" . }}
-      automountServiceAccountToken: {{ .Values.kyverno-plugin.serviceAccount.automount }}
+      automountServiceAccountToken: {{ .Values.plugin.kyverno.serviceAccount.automount }}
       {{- if .Values.plugin.kyverno.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.plugin.kyverno.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kyverno-plugin.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.kyverno-plugin.serviceAccount.automount }}
       {{- if .Values.plugin.kyverno.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.plugin.kyverno.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "trivy-plugin.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.trivy-plugin.serviceAccount.automount }}
       {{- if .Values.plugin.trivy.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.plugin.trivy.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "trivy-plugin.serviceAccountName" . }}
-      automountServiceAccountToken: {{ .Values.trivy-plugin.serviceAccount.automount }}
+      automountServiceAccountToken: {{ .Values.plugin.trivy.serviceAccount.automount }}
       {{- if .Values.plugin.trivy.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.plugin.trivy.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/templates/ui/deployment.yaml
+++ b/charts/policy-reporter/templates/ui/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ui.serviceAccount.automount }}
       {{- if .Values.ui.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.ui.podSecurityContext | nindent 8 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -51,7 +51,7 @@ rbac:
 serviceAccount:
   # -- Create ServiceAccount
   create: true
-  # -- Enable ServiceAccount automaount
+  # -- Enable ServiceAccount automount
   automount: true
   # -- Annotations for the ServiceAccount
   annotations: {}
@@ -974,7 +974,7 @@ ui:
   serviceAccount:
     # -- Create ServiceAccount
     create: true
-    # -- Enable ServiceAccount automaount
+    # -- Enable ServiceAccount automount
     automount: true
     # -- Annotations for the ServiceAccount
     annotations: {}
@@ -1183,7 +1183,7 @@ plugin:
     serviceAccount:
       # -- Create ServiceAccount
       create: true
-      # -- Enable ServiceAccount automaount
+      # -- Enable ServiceAccount automount
       automount: true
       # -- Annotations for the ServiceAccount
       annotations: {}
@@ -1371,7 +1371,7 @@ plugin:
     serviceAccount:
       # -- Create ServiceAccount
       create: true
-      # -- Enable ServiceAccount automaount
+      # -- Enable ServiceAccount automount
       automount: true
       # -- Annotations for the ServiceAccount
       annotations: {}


### PR DESCRIPTION
The deployment for policy-reporter had hardcoded automountServiceAccountToken and never used serviceAccount.automount at all. 
In addition the ui, kyverno-plugin and trivy-plugin used their corresponding value only in the ServiceAccount-resource - this Pull Request configures their respective Deployments to also use the serviceAccount.automount.

+ fix of minor typos