### PR TITLE
Feature: Add extraVolumes-attribute to kyverno- and trivy-plugin

### DIFF
--- a/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             mountPath: /app/config.yaml
             subPath: config.yaml
             readOnly: true
+          {{- with .Values.plugin.kyverno.extraVolumes.volumeMounts }}
+          {{ toYaml . | nindent 10 | trim }}
+          {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -89,6 +92,9 @@ spec:
         secret:
           secretName: {{ include "kyverno-plugin.fullname" . }}-config
           optional: true
+      {{- with .Values.plugin.kyverno.extraVolumes.volumes }}
+      {{ toYaml . | nindent 6 | trim }}
+      {{- end }}
       {{- with .Values.plugin.kyverno.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
@@ -70,6 +70,9 @@ spec:
             mountPath: /app/config.yaml
             subPath: config.yaml
             readOnly: true
+          {{- with .Values.plugin.trivy.extraVolumes.volumeMounts }}
+          {{ toYaml . | nindent 10 | trim }}
+          {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -83,6 +86,9 @@ spec:
         secret:
           secretName: {{ include "trivy-plugin.fullname" . }}-config
           optional: true
+      {{- with .Values.plugin.trivy.extraVolumes.volumes }}
+      {{ toYaml . | nindent 6 | trim }}
+      {{- end }}
       {{- with .Values.plugin.trivy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1326,6 +1326,13 @@ plugin:
       # -- Affinity constraints.
     affinity: {}
 
+    extraVolumes:
+      # -- Deployment volumeMounts
+      volumeMounts: []
+
+      # -- Deployment values
+      volumes: []
+
   trivy:
       # -- (bool) Enable Trivy Operator Plugin
     enabled: false
@@ -1498,6 +1505,13 @@ plugin:
 
       # -- Affinity constraints.
     affinity: {}
+
+    extraVolumes:
+      # -- Deployment volumeMounts
+      volumeMounts: []
+
+      # -- Deployment values
+      volumes: []
 
 monitoring:
   # -- Enables the Prometheus Operator integration


### PR DESCRIPTION
This PR allows defining volumes and volumeMounts for the kyverno-plugin and the trivy-plugin in the chart, which for example is necessary if not automounting the service account, which could be prohibited by a cluster policy.