### PR TITLE
Fix: Respect monitoring.grafana.namespace value

### DIFF
--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -112,6 +112,15 @@ maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end -}}
 {{- end -}}
 
+{{/* Get the namespace name for grafana. */}}
+{{- define "grafana.namespace" -}}
+{{- if .Values.monitoring.grafana.namespace -}}
+    {{- .Values.monitoring.grafana.namespace -}}
+{{- else -}}
+    {{- include "policyreporter.namespace" . -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Get the namespace name. */}}
 {{- define "policyreporter.logLevel" -}}
 {{- if .Values.logging.server -}}

--- a/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-clusterpolicy-details-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
   annotations:
     {{ $root.grafana.folder.annotation }}: {{ $root.grafana.folder.name }}
     {{- with .Values.annotations }}

--- a/charts/policy-reporter/templates/monitoring/clusterpolicy-details.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/clusterpolicy-details.grafanadashboard.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ .Values.monitoring.grafana.dashboards.label }}: {{ .Values.monitoring.grafana.dashboards.value | quote }}
     {{- include "monitoring.labels" . | nindent 4 }}
   name: {{ include "monitoring.fullname" . }}-clusterpolicy-details-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
 spec:
   allowCrossNamespaceImport: {{ .Values.monitoring.grafana.grafanaDashboard.allowCrossNamespaceImport }}
   folder: {{ .Values.monitoring.grafana.grafanaDashboard.folder }}

--- a/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-overview-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
   annotations:
     {{ $root.grafana.folder.annotation }}: {{ $root.grafana.folder.name }}
     {{- with .Values.annotations }}

--- a/charts/policy-reporter/templates/monitoring/overview.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/overview.grafanadashboard.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ .Values.monitoring.grafana.dashboards.label }}: {{ .Values.monitoring.grafana.dashboards.value | quote }}
     {{- include "monitoring.labels" . | nindent 4 }}
   name: {{ include "monitoring.fullname" . }}-overview-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
 spec:
   allowCrossNamespaceImport: {{ .Values.monitoring.grafana.grafanaDashboard.allowCrossNamespaceImport }}
   folder: {{ .Values.monitoring.grafana.grafanaDashboard.folder }}

--- a/charts/policy-reporter/templates/monitoring/policy-details.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/policy-details.dashboard.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "monitoring.fullname" . }}-policy-details-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
   annotations:
     {{ $root.grafana.folder.annotation }}: {{ $root.grafana.folder.name }}
     {{- with .Values.annotations }}

--- a/charts/policy-reporter/templates/monitoring/policy-details.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/policy-details.grafanadashboard.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ .Values.monitoring.grafana.dashboards.label }}: {{ .Values.monitoring.grafana.dashboards.value | quote }}
     {{- include "monitoring.labels" . | nindent 4 }}
   name: {{ include "monitoring.fullname" . }}-policy-details-dashboard
-  namespace: {{ include "policyreporter.namespace" . }}
+  namespace: {{ include "grafana.namespace" . }}
 spec:
   allowCrossNamespaceImport: {{ .Values.monitoring.grafana.grafanaDashboard.allowCrossNamespaceImport }}
   folder: {{ .Values.monitoring.grafana.grafanaDashboard.folder }}


### PR DESCRIPTION
Use monitoring.grafana.namespace value for namespace when creating grafanadashboard or configmap resources for grafana.
This PR falls back to use policyreporter.namespace if monitoring.grafana.namespace is not set.