### PR TITLE
kyverno/policy-reporter#595: add typelessApi option to Elasticsearch target config in _helpers.tpl

### DIFF
--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -169,6 +169,7 @@ config:
   apiKey: {{ .apiKey | quote }}
   index: {{ .index| quote }}
   rotation: {{ .rotation | quote }}
+  typelessApi: {{ .typelessApi | quote }}
 {{ include "target" . }}
 {{- end }}
 


### PR DESCRIPTION
Addresses [Bug: [v3] Elasticsearch target in _helpers.tpl missing typelessApi option #595](https://github.com/kyverno/policy-reporter/issues/595)
