### PR TITLE
feat(manifests): Generate static manifests from the Helm Chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,38 @@ kind-load: $(KIND) ko-build ## Build playground image and load it in kind cluste
 # CODEGEN #
 ###########
 
+.PHONY: codegen-static-manifests
+codegen-static-manifests: $(HELM) ## Generate helm docs
+	@echo Generate static manifests... >&2
+	@$(HELM) template policy-reporter ./charts/policy-reporter \
+		--set static=true \
+		--set metrics.enabled=true \
+		--set rest.enabled=true \
+		-n policy-reporter \
+		--create-namespace > manifests/policy-reporter/install.yaml
+	@$(HELM) template policy-reporter ./charts/policy-reporter \
+		--set static=true \
+		--set metrics.enabled=true \
+		--set ui.enabled=true \
+		-n policy-reporter \
+		--create-namespace > manifests/policy-reporter-ui/install.yaml
+	@$(HELM) template policy-reporter ./charts/policy-reporter --set static=true \
+		--set metrics.enabled=true \
+		--set ui.enabled=true \
+		--set plugin.kyverno.enabled=true \
+		-n policy-reporter \
+		--create-namespace > manifests/policy-reporter-kyverno-ui/install.yaml
+	@$(HELM) template policy-reporter ./charts/policy-reporter \
+		--set static=true \
+		--set metrics.enabled=true \
+		--set ui.enabled=true \
+		--set plugin.kyverno.enabled=true \
+		--set replicaCount=2 \
+		--set ui.replicaCount=2 \
+		--set plugin.kyverno.replicaCount=2 \
+		-n policy-reporter \
+		--create-namespace > manifests/policy-reporter-kyverno-ui-ha/install.yaml
+
 .PHONY: codegen-helm-docs
 codegen-helm-docs: ## Generate helm docs
 	@echo Generate helm docs... >&2

--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -29,14 +29,16 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "policyreporter.labels" -}}
-helm.sh/chart: {{ include "policyreporter.chart" . }}
 {{ include "policyreporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/component: reporting
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: policy-reporter
+{{- if not .Values.static }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "policyreporter.chart" . }}
+{{- end }}
 {{- with .Values.global.labels }}
 {{ toYaml . }}
 {{- end -}}
@@ -46,9 +48,11 @@ app.kubernetes.io/part-of: policy-reporter
 Pod labels
 */}}
 {{- define "policyreporter.podLabels" -}}
-helm.sh/chart: {{ include "policyreporter.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/part-of: policy-reporter
+{{- if not .Values.static }}
+helm.sh/chart: {{ include "policyreporter.chart" . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/policy-reporter/templates/cluster-secret.yaml
+++ b/charts/policy-reporter/templates/cluster-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ui.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,3 +25,4 @@ data:
   {{- $host := printf "http://%s:%d/vulnr" (include "trivy-plugin.fullname" .) (.Values.plugin.trivy.service.port | int) }}
   plugin.trivy: {{ (printf "{\"host\":\"%s\", \"name\":\"Trivy Vulnerability\", \"username\":\"%s\", \"password\":\"%s\"}" $host $username $password) | b64enc }}
   {{- end }}
+{{- end }}

--- a/charts/policy-reporter/templates/monitoring/_helpers.tpl
+++ b/charts/policy-reporter/templates/monitoring/_helpers.tpl
@@ -23,13 +23,17 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "monitoring.labels" -}}
+{{- if not .Values.static }}
 helm.sh/chart: {{ include "monitoring.chart" . }}
+{{- end -}}
 {{ include "monitoring.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/component: monitoring
+{{- if not .Values.static }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 app.kubernetes.io/part-of: kyverno
 {{- with .Values.global.labels }}
 {{ toYaml . }}

--- a/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.monitoring.enabled }}
 {{ $root := .Values.monitoring }}
 
 {{- if and $root.grafana.dashboards.enabled $root.grafana.dashboards.enable.clusterPolicyReportDetails }}
@@ -931,4 +932,5 @@ data:
     "uid": "iyJszGUMk",
     "version": 1
     }
+{{- end }}
 {{- end }}

--- a/charts/policy-reporter/templates/monitoring/clusterpolicy-details.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/clusterpolicy-details.grafanadashboard.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.clusterPolicyReportDetails .Values.monitoring.grafana.grafanaDashboard.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.clusterPolicyReportDetails .Values.monitoring.grafana.grafanaDashboard.enabled }}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.monitoring.enabled }}
 {{ $root := .Values.monitoring }}
 
 {{- if and $root.grafana.dashboards.enabled $root.grafana.dashboards.enable.overview }}
@@ -687,4 +688,5 @@ data:
     "title": "PolicyReports",
     "version": 1
     }
+{{- end }}
 {{- end }}

--- a/charts/policy-reporter/templates/monitoring/overview.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/overview.grafanadashboard.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.overview .Values.monitoring.grafana.grafanaDashboard.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.overview .Values.monitoring.grafana.grafanaDashboard.enabled }}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/charts/policy-reporter/templates/monitoring/policy-details.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/policy-details.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.monitoring.enabled }}
 {{ $root := .Values.monitoring }}
 
 {{- if and $root.grafana.dashboards.enabled $root.grafana.dashboards.enable.policyReportDetails }}
@@ -970,4 +971,5 @@ data:
     "uid": "Tf1skG8Mz",
     "version": 1
     }
+{{- end }}
 {{- end }}

--- a/charts/policy-reporter/templates/monitoring/policy-details.grafanadashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/policy-details.grafanadashboard.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.policyReportDetails .Values.monitoring.grafana.grafanaDashboard.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana.dashboards.enabled .Values.monitoring.grafana.dashboards.enable.policyReportDetails .Values.monitoring.grafana.grafanaDashboard.enabled }}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/charts/policy-reporter/templates/plugins/kyverno/_helpers.tpl
+++ b/charts/policy-reporter/templates/plugins/kyverno/_helpers.tpl
@@ -25,12 +25,14 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "kyverno-plugin.labels" -}}
-helm.sh/chart: {{ include "kyverno-plugin.chart" . }}
 {{ include "kyverno-plugin.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if not .Values.static }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kyverno-plugin.chart" . }}
+{{- end -}}
 {{- with .Values.global.labels }}
 {{ toYaml . }}
 {{- end -}}

--- a/charts/policy-reporter/templates/plugins/trivy/_helpers.tpl
+++ b/charts/policy-reporter/templates/plugins/trivy/_helpers.tpl
@@ -25,12 +25,14 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "trivy-plugin.labels" -}}
-helm.sh/chart: {{ include "trivy-plugin.chart" . }}
 {{ include "trivy-plugin.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if not .Values.static }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "trivy-plugin.chart" . }}
+{{- end }}
 {{- with .Values.global.labels }}
 {{ toYaml . }}
 {{- end -}}

--- a/charts/policy-reporter/templates/ui/_helpers.tpl
+++ b/charts/policy-reporter/templates/ui/_helpers.tpl
@@ -25,12 +25,14 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "ui.labels" -}}
-helm.sh/chart: {{ include "ui.chart" . }}
 {{ include "ui.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if not .Values.static }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "ui.chart" . }}
+{{- end }}
 {{- with .Values.global.labels }}
 {{ toYaml . }}
 {{- end -}}

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,37 @@
+# Installation Manifests for Policy Reporter
+
+You can use this manifests to install Policy Reporter without additional tools like Helm or Kustomize. The manifests are structured into five installations.
+
+The installation requires to be in the `policy-reporter` namespace. As its the configured namespaces for RBAC resources.
+
+## Policy Reporter
+
+The `policy-reporter` folder is a basic installation for Policy Reporter without the UI or other components. It runs with the REST API and Metrics Endpoint enabled.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kyverno/policy-reporter/main/manifests/policy-reporter/install.yaml
+```
+
+## Policy Reporter UI
+
+The `policy-reporter-ui` folder installs Policy Reporter together with the Policy Reporter UI components and Metrics enabled.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kyverno/policy-reporter/main/manifests/policy-reporter-ui/install.yaml
+```
+
+## Policy Reporter UI + Kyverno Plugin
+
+The `policy-reporter-kyverno-ui` folder installs Policy Reporter together with the Policy Reporter UI, Kyverno Plugin components and Metrics enabled.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kyverno/policy-reporter/main/manifests/policy-reporter-kyverno-ui/install.yaml
+```
+
+## Policy Reporter UI + Kyverno Plugin in HA Mode
+
+The `policy-reporter-kyverno-ui-ha` installs the same compoments as `policy-reporter-kyverno-ui` but runs all components in HA mode (2 replicas) and creates additional resources for leader elections.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kyverno/policy-reporter/main/manifests/policy-reporter-kyverno-ui-ha/install.yaml
+```

--- a/manifests/policy-reporter-kyverno-ui-ha/install.yaml
+++ b/manifests/policy-reporter-kyverno-ui-ha/install.yaml
@@ -1,0 +1,747 @@
+---
+# Source: policy-reporter/templates/plugins/kyverno/poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: policy-reporter-kyverno-plugin
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:  
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-kyverno-plugin
+      app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:  
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/ui/poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:  
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-ui
+      app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+automountServiceAccountToken: true
+---
+# Source: policy-reporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+---
+# Source: policy-reporter/templates/ui/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+automountServiceAccountToken: true
+---
+# Source: policy-reporter/templates/cluster-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-default-cluster
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  host: aHR0cDovL3BvbGljeS1yZXBvcnRlcjo4MDgw
+  username: 
+  password: 
+  plugin.kyverno: eyJob3N0IjoiaHR0cDovL3BvbGljeS1yZXBvcnRlci1reXZlcm5vLXBsdWdpbjo4MDgwIiwgIm5hbWUiOiJreXZlcm5vIiwgInVzZXJuYW1lIjoiIiwgInBhc3N3b3JkIjoiIn0=
+---
+# Source: policy-reporter/templates/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  config.yaml: dGFyZ2V0OgogIGxva2k6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICBwYXRoOiAiIgogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGVsYXN0aWNzZWFyY2g6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICB1c2VybmFtZTogIiIKICAgICAgcGFzc3dvcmQ6ICIiCiAgICAgIGFwaUtleTogIiIKICAgICAgaW5kZXg6ICJwb2xpY3ktcmVwb3J0ZXIiCiAgICAgIHJvdGF0aW9uOiAiZGFpbHkiCiAgICAgIHR5cGVsZXNzQXBpOiAiZmFsc2UiCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgc2xhY2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNoYW5uZWw6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAKICAgICAgc2tpcFRMUzogCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZGlzY29yZDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgdGVhbXM6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHdlYmhvb2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHRlbGVncmFtOgogICAgY29uZmlnOgogICAgICBjaGF0SWQ6ICIiCiAgICAgIHRva2VuOiAiIgogICAgICB3ZWJob29rOiAKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZ29vZ2xlQ2hhdDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgczM6CiAgICBjb25maWc6CiAgICAgIGFjY2Vzc0tleUlkOiAKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgCiAgICAgIHJlZ2lvbjogCiAgICAgIGVuZHBvaW50OiAKICAgICAgYnVja2V0OiAKICAgICAgYnVja2V0S2V5RW5hYmxlZDogZmFsc2UKICAgICAga21zS2V5SWQ6IAogICAgICBzZXJ2ZXJTaWRlRW5jcnlwdGlvbjogCiAgICAgIHBhdGhTdHlsZTogZmFsc2UKICAgICAgcHJlZml4OiAKICAgIG5hbWU6IAogICAgc2VjcmV0UmVmOiAiIgogICAgbW91bnRlZFNlY3JldDogIiIKICAgIG1pbmltdW1TZXZlcml0eTogIiIKICAgIHNraXBFeGlzdGluZ09uU3RhcnR1cDogdHJ1ZQoKICBraW5lc2lzOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogCiAgICAgIHNlY3JldEFjY2Vzc0tleTogIAogICAgICByZWdpb246IAogICAgICBlbmRwb2ludDogCiAgICAgIHN0cmVhbU5hbWU6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHNlY3VyaXR5SHViOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogIiIKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgIiIKICAgICAgcmVnaW9uOiAKICAgICAgZW5kcG9pbnQ6IAogICAgICBhY2NvdW50SWQ6ICIiCiAgICAgIHByb2R1Y3ROYW1lOiAKICAgICAgY29tcGFueU5hbWU6IAogICAgICBkZWxheUluU2Vjb25kczogMgogICAgICBzeW5jaHJvbml6ZTogdHJ1ZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGdjczoKICAgIGNvbmZpZzoKICAgICAgY3JlZGVudGlhbHM6IAogICAgICBidWNrZXQ6IAogICAgICBwcmVmaXg6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgp3b3JrZXI6IDUKbWV0cmljczoKICBjdXN0b21MYWJlbHM6IFtdCiAgZW5hYmxlZDogdHJ1ZQogIGZpbHRlcjoge30KICBtb2RlOiBkZXRhaWxlZApzb3VyY2VGaWx0ZXJzOgogIC0gZGlzYWJsZUNsdXN0ZXJSZXBvcnRzOiBmYWxzZQogICAga2luZHM6CiAgICAgIGV4Y2x1ZGU6CiAgICAgIC0gUmVwbGljYVNldAogICAgc2VsZWN0b3I6CiAgICAgIHNvdXJjZToga3l2ZXJubwogICAgdW5jb250cm9sbGVkT25seTogdHJ1ZQoKbGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogdHJ1ZQogIHJlbGVhc2VPbkNhbmNlbDogdHJ1ZQogIGxlYXNlRHVyYXRpb246IDE1CiAgcmVuZXdEZWFkbGluZTogMTAKICByZXRyeVBlcmlvZDogMgpyZWRpczoKICBhZGRyZXNzOiAiIgogIGRhdGFiYXNlOiAwCiAgZW5hYmxlZDogZmFsc2UKICBwYXNzd29yZDogIiIKICBwcmVmaXg6IHBvbGljeS1yZXBvcnRlcgogIHVzZXJuYW1lOiAiIgoKbG9nZ2luZzoKICBzZXJ2ZXI6IGZhbHNlCiAgZW5jb2Rpbmc6IGNvbnNvbGUKICBsb2dMZXZlbDogMAoKYXBpOgogIGJhc2ljQXV0aDoKICAgIHVzZXJuYW1lOiAKICAgIHBhc3N3b3JkOiAKICAgIHNlY3JldFJlZjogCgpkYXRhYmFzZToKICB0eXBlOiAKICBkYXRhYmFzZTogCiAgdXNlcm5hbWU6IAogIHBhc3N3b3JkOiAKICBob3N0OiAKICBlbmFibGVTU0w6IGZhbHNlCiAgZHNuOiAKICBzZWNyZXRSZWY6IAogIG1vdW50ZWRTZWNyZXQ6IAo=
+---
+# Source: policy-reporter/templates/plugins/kyverno/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-kyverno-plugin-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+type: Opaque
+data:
+  config.yaml: bGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogdHJ1ZQogIHJlbGVhc2VPbkNhbmNlbDogdHJ1ZQogIGxlYXNlRHVyYXRpb246IDE1CiAgcmVuZXdEZWFkbGluZTogMTAKICByZXRyeVBlcmlvZDogMgogIGxvY2tOYW1lOiBreXZlcm5vLXBsdWdpbgoKbG9nZ2luZzoKICBhcGk6IGZhbHNlCiAgc2VydmVyOiBmYWxzZQogIGVuY29kaW5nOiBjb25zb2xlCiAgbG9nTGV2ZWw6IDAKCnNlcnZlcjoKICBiYXNpY0F1dGg6CiAgICB1c2VybmFtZTogCiAgICBwYXNzd29yZDogCiAgICBzZWNyZXRSZWY6IAoKY29yZToKICBob3N0OiBodHRwOi8vcG9saWN5LXJlcG9ydGVyOjgwODAKYmxvY2tSZXBvcnRzOgogICAgZW5hYmxlZDogZmFsc2UKICAgIGV2ZW50TmFtZXNwYWNlOiBkZWZhdWx0CiAgICBwb2xpY3lSZXBvcnQ6CiAgICAgIGFubm90YXRpb25zOiBbXQogICAgICBsYWJlbHM6IFtdCiAgICByZXN1bHRzOgogICAgICBrZWVwT25seUxhdGVzdDogZmFsc2UKICAgICAgbWF4UGVyUmVwb3J0OiAyMDAKICAgIHNvdXJjZTogS3l2ZXJubyBFdmVudAo=
+---
+# Source: policy-reporter/templates/ui/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+type: Opaque
+data:
+  config.yaml: bmFtZXNwYWNlOiBwb2xpY3ktcmVwb3J0ZXIKCnRlbXBEaXI6IC90bXAKCmxvZ2dpbmc6CiAgYXBpOiBmYWxzZQogIHNlcnZlcjogZmFsc2UKICBlbmNvZGluZzogY29uc29sZQogIGxvZ0xldmVsOiAwCgpzZXJ2ZXI6CiAgcG9ydDogODA4MAogIGNvcnM6IHRydWUKICBvdmVyd3JpdGVIb3N0OiB0cnVlCgp1aToKICBkaXNwbGF5TW9kZTogCiAgYmFubmVyOiAKCmNsdXN0ZXJzOgogIC0gbmFtZTogRGVmYXVsdAogICAgc2VjcmV0UmVmOiBwb2xpY3ktcmVwb3J0ZXItdWktZGVmYXVsdC1jbHVzdGVyCgpzb3VyY2VzOgogIC0gbmFtZToga3l2ZXJubwogICAgY2hhcnRUeXBlOiByZXN1bHQKICAgIGV4Y2VwdGlvbnM6IGZhbHNlCiAgICBleGNsdWRlczoKICAgICAgcmVzdWx0czoKICAgICAgLSB3YXJuCiAgICAgIC0gZXJyb3IKb3BlbklEQ29ubmVjdDoKICAgIGNhbGxiYWNrVXJsOiAiIgogICAgY2xpZW50SWQ6ICIiCiAgICBjbGllbnRTZWNyZXQ6ICIiCiAgICBkaXNjb3ZlcnlVcmw6ICIiCiAgICBlbmFibGVkOiBmYWxzZQogICAgZ3JvdXBDbGFpbTogIiIKICAgIHNjb3BlczogW10KICAgIHNlY3JldFJlZjogIiIKb2F1dGg6CiAgICBjYWxsYmFja1VybDogIiIKICAgIGNsaWVudElkOiAiIgogICAgY2xpZW50U2VjcmV0OiAiIgogICAgZW5hYmxlZDogZmFsc2UKICAgIHByb3ZpZGVyOiAiIgogICAgc2NvcGVzOiBbXQogICAgc2VjcmV0UmVmOiAiIgo=
+---
+# Source: policy-reporter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - 'batch'
+  resources:
+  - jobs
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/plugins/kyverno/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-kyverno-plugin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policies
+  - policies/status
+  - clusterpolicies
+  - clusterpolicies/status
+  verbs:
+  - get
+  - list
+---
+# Source: policy-reporter/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter-kyverno-plugin
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter-kyverno-plugin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-kyverno-plugin-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter-leaderelection
+  namespace: policy-reporter
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+---
+# Source: policy-reporter/templates/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: policy-reporter/templates/ui/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/plugins/kyverno/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-kyverno-plugin-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: Role
+  name: policy-reporter-kyverno-plugin-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-leaderelection
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: Role
+  name: policy-reporter-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: Role
+  name: policy-reporter-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/ui/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: Role
+  name: policy-reporter-ui-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-ui
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/ui/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-reporter
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+        app.kubernetes.io/part-of: policy-reporter
+      annotations:
+        checksum/secret: "6a02966bee0724f8254766413135e0ba4dda517d1076d8913426e0352d407a7e"
+    spec:
+      serviceAccountName: policy-reporter
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1234
+      containers:
+        - name: policy-reporter
+          image: "ghcr.io/kyverno/policy-reporter:3.0.0-rc.7"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --port=8080
+            - --config=/app/config.yaml
+            - --dbfile=/sqlite/database.db
+            - --metrics-enabled=true
+            - --rest-enabled=true
+            - --profile=false
+            - --lease-name=policy-reporter
+            - --template-dir=/app/templates
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: sqlite
+            mountPath: /sqlite
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      volumes:
+      - name: sqlite
+        emptyDir: {}
+      - name: config-file
+        secret:
+          secretName: policy-reporter-config
+          optional: true
+      - name: tmp
+        emptyDir: {}
+---
+# Source: policy-reporter/templates/plugins/kyverno/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-kyverno-plugin
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      annotations:
+        checksum/secret: "28dc68395302056d0dc854c8bf1f92dfd9b203560f35c1acb23e7e33cc317c57"
+      labels:
+        app.kubernetes.io/name: policy-reporter-kyverno-plugin
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+    spec:
+      serviceAccountName: policy-reporter-kyverno-plugin
+      automountServiceAccountToken: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 1234
+      containers:
+        - name: policy-reporter-kyverno-plugin
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kyverno/policy-reporter/kyverno-plugin:0.4.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --config=/app/config.yaml
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /v1/policies
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /v1/policies
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+      volumes:
+      - name: config-file
+        secret:
+          secretName: policy-reporter-kyverno-plugin-config
+          optional: true
+---
+# Source: policy-reporter/templates/ui/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-ui
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      annotations:
+        checksum/secret: "c336e3fc53788dec3d2dd67957cdbba64ac9a7d19271f13c51ae6de1b1ede213"
+        checksum/cluster-secret: "103aa626cc0599d7252bb79b0e24738bd359f6231cf85f5bdb8894659099c79f"
+      labels:
+        app.kubernetes.io/name: policy-reporter-ui
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+    spec:
+      serviceAccountName: policy-reporter-ui
+      automountServiceAccountToken: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 1234
+      containers:
+        - name: policy-reporter-ui
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kyverno/policy-reporter-ui:2.0.0-rc.3"
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --config=/app/config.yaml
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: config-file
+        secret:
+          secretName: policy-reporter-ui-config
+          optional: true
+      - name: tmp
+        emptyDir: {}

--- a/manifests/policy-reporter-kyverno-ui/install.yaml
+++ b/manifests/policy-reporter-kyverno-ui/install.yaml
@@ -1,0 +1,642 @@
+---
+# Source: policy-reporter/templates/plugins/kyverno/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+automountServiceAccountToken: true
+---
+# Source: policy-reporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+---
+# Source: policy-reporter/templates/ui/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+automountServiceAccountToken: true
+---
+# Source: policy-reporter/templates/cluster-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-default-cluster
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  host: aHR0cDovL3BvbGljeS1yZXBvcnRlcjo4MDgw
+  username: 
+  password: 
+  plugin.kyverno: eyJob3N0IjoiaHR0cDovL3BvbGljeS1yZXBvcnRlci1reXZlcm5vLXBsdWdpbjo4MDgwIiwgIm5hbWUiOiJreXZlcm5vIiwgInVzZXJuYW1lIjoiIiwgInBhc3N3b3JkIjoiIn0=
+---
+# Source: policy-reporter/templates/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  config.yaml: dGFyZ2V0OgogIGxva2k6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICBwYXRoOiAiIgogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGVsYXN0aWNzZWFyY2g6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICB1c2VybmFtZTogIiIKICAgICAgcGFzc3dvcmQ6ICIiCiAgICAgIGFwaUtleTogIiIKICAgICAgaW5kZXg6ICJwb2xpY3ktcmVwb3J0ZXIiCiAgICAgIHJvdGF0aW9uOiAiZGFpbHkiCiAgICAgIHR5cGVsZXNzQXBpOiAiZmFsc2UiCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgc2xhY2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNoYW5uZWw6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAKICAgICAgc2tpcFRMUzogCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZGlzY29yZDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgdGVhbXM6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHdlYmhvb2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHRlbGVncmFtOgogICAgY29uZmlnOgogICAgICBjaGF0SWQ6ICIiCiAgICAgIHRva2VuOiAiIgogICAgICB3ZWJob29rOiAKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZ29vZ2xlQ2hhdDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgczM6CiAgICBjb25maWc6CiAgICAgIGFjY2Vzc0tleUlkOiAKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgCiAgICAgIHJlZ2lvbjogCiAgICAgIGVuZHBvaW50OiAKICAgICAgYnVja2V0OiAKICAgICAgYnVja2V0S2V5RW5hYmxlZDogZmFsc2UKICAgICAga21zS2V5SWQ6IAogICAgICBzZXJ2ZXJTaWRlRW5jcnlwdGlvbjogCiAgICAgIHBhdGhTdHlsZTogZmFsc2UKICAgICAgcHJlZml4OiAKICAgIG5hbWU6IAogICAgc2VjcmV0UmVmOiAiIgogICAgbW91bnRlZFNlY3JldDogIiIKICAgIG1pbmltdW1TZXZlcml0eTogIiIKICAgIHNraXBFeGlzdGluZ09uU3RhcnR1cDogdHJ1ZQoKICBraW5lc2lzOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogCiAgICAgIHNlY3JldEFjY2Vzc0tleTogIAogICAgICByZWdpb246IAogICAgICBlbmRwb2ludDogCiAgICAgIHN0cmVhbU5hbWU6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHNlY3VyaXR5SHViOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogIiIKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgIiIKICAgICAgcmVnaW9uOiAKICAgICAgZW5kcG9pbnQ6IAogICAgICBhY2NvdW50SWQ6ICIiCiAgICAgIHByb2R1Y3ROYW1lOiAKICAgICAgY29tcGFueU5hbWU6IAogICAgICBkZWxheUluU2Vjb25kczogMgogICAgICBzeW5jaHJvbml6ZTogdHJ1ZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGdjczoKICAgIGNvbmZpZzoKICAgICAgY3JlZGVudGlhbHM6IAogICAgICBidWNrZXQ6IAogICAgICBwcmVmaXg6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgp3b3JrZXI6IDUKbWV0cmljczoKICBjdXN0b21MYWJlbHM6IFtdCiAgZW5hYmxlZDogdHJ1ZQogIGZpbHRlcjoge30KICBtb2RlOiBkZXRhaWxlZApzb3VyY2VGaWx0ZXJzOgogIC0gZGlzYWJsZUNsdXN0ZXJSZXBvcnRzOiBmYWxzZQogICAga2luZHM6CiAgICAgIGV4Y2x1ZGU6CiAgICAgIC0gUmVwbGljYVNldAogICAgc2VsZWN0b3I6CiAgICAgIHNvdXJjZToga3l2ZXJubwogICAgdW5jb250cm9sbGVkT25seTogdHJ1ZQoKbGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogZmFsc2UKICByZWxlYXNlT25DYW5jZWw6IHRydWUKICBsZWFzZUR1cmF0aW9uOiAxNQogIHJlbmV3RGVhZGxpbmU6IDEwCiAgcmV0cnlQZXJpb2Q6IDIKcmVkaXM6CiAgYWRkcmVzczogIiIKICBkYXRhYmFzZTogMAogIGVuYWJsZWQ6IGZhbHNlCiAgcGFzc3dvcmQ6ICIiCiAgcHJlZml4OiBwb2xpY3ktcmVwb3J0ZXIKICB1c2VybmFtZTogIiIKCmxvZ2dpbmc6CiAgc2VydmVyOiBmYWxzZQogIGVuY29kaW5nOiBjb25zb2xlCiAgbG9nTGV2ZWw6IDAKCmFwaToKICBiYXNpY0F1dGg6CiAgICB1c2VybmFtZTogCiAgICBwYXNzd29yZDogCiAgICBzZWNyZXRSZWY6IAoKZGF0YWJhc2U6CiAgdHlwZTogCiAgZGF0YWJhc2U6IAogIHVzZXJuYW1lOiAKICBwYXNzd29yZDogCiAgaG9zdDogCiAgZW5hYmxlU1NMOiBmYWxzZQogIGRzbjogCiAgc2VjcmV0UmVmOiAKICBtb3VudGVkU2VjcmV0OiAK
+---
+# Source: policy-reporter/templates/plugins/kyverno/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-kyverno-plugin-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+type: Opaque
+data:
+  config.yaml: bGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogZmFsc2UKICByZWxlYXNlT25DYW5jZWw6IHRydWUKICBsZWFzZUR1cmF0aW9uOiAxNQogIHJlbmV3RGVhZGxpbmU6IDEwCiAgcmV0cnlQZXJpb2Q6IDIKICBsb2NrTmFtZToga3l2ZXJuby1wbHVnaW4KCmxvZ2dpbmc6CiAgYXBpOiBmYWxzZQogIHNlcnZlcjogZmFsc2UKICBlbmNvZGluZzogY29uc29sZQogIGxvZ0xldmVsOiAwCgpzZXJ2ZXI6CiAgYmFzaWNBdXRoOgogICAgdXNlcm5hbWU6IAogICAgcGFzc3dvcmQ6IAogICAgc2VjcmV0UmVmOiAKCmNvcmU6CiAgaG9zdDogaHR0cDovL3BvbGljeS1yZXBvcnRlcjo4MDgwCmJsb2NrUmVwb3J0czoKICAgIGVuYWJsZWQ6IGZhbHNlCiAgICBldmVudE5hbWVzcGFjZTogZGVmYXVsdAogICAgcG9saWN5UmVwb3J0OgogICAgICBhbm5vdGF0aW9uczogW10KICAgICAgbGFiZWxzOiBbXQogICAgcmVzdWx0czoKICAgICAga2VlcE9ubHlMYXRlc3Q6IGZhbHNlCiAgICAgIG1heFBlclJlcG9ydDogMjAwCiAgICBzb3VyY2U6IEt5dmVybm8gRXZlbnQK
+---
+# Source: policy-reporter/templates/ui/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+type: Opaque
+data:
+  config.yaml: bmFtZXNwYWNlOiBwb2xpY3ktcmVwb3J0ZXIKCnRlbXBEaXI6IC90bXAKCmxvZ2dpbmc6CiAgYXBpOiBmYWxzZQogIHNlcnZlcjogZmFsc2UKICBlbmNvZGluZzogY29uc29sZQogIGxvZ0xldmVsOiAwCgpzZXJ2ZXI6CiAgcG9ydDogODA4MAogIGNvcnM6IHRydWUKICBvdmVyd3JpdGVIb3N0OiB0cnVlCgp1aToKICBkaXNwbGF5TW9kZTogCiAgYmFubmVyOiAKCmNsdXN0ZXJzOgogIC0gbmFtZTogRGVmYXVsdAogICAgc2VjcmV0UmVmOiBwb2xpY3ktcmVwb3J0ZXItdWktZGVmYXVsdC1jbHVzdGVyCgpzb3VyY2VzOgogIC0gbmFtZToga3l2ZXJubwogICAgY2hhcnRUeXBlOiByZXN1bHQKICAgIGV4Y2VwdGlvbnM6IGZhbHNlCiAgICBleGNsdWRlczoKICAgICAgcmVzdWx0czoKICAgICAgLSB3YXJuCiAgICAgIC0gZXJyb3IKb3BlbklEQ29ubmVjdDoKICAgIGNhbGxiYWNrVXJsOiAiIgogICAgY2xpZW50SWQ6ICIiCiAgICBjbGllbnRTZWNyZXQ6ICIiCiAgICBkaXNjb3ZlcnlVcmw6ICIiCiAgICBlbmFibGVkOiBmYWxzZQogICAgZ3JvdXBDbGFpbTogIiIKICAgIHNjb3BlczogW10KICAgIHNlY3JldFJlZjogIiIKb2F1dGg6CiAgICBjYWxsYmFja1VybDogIiIKICAgIGNsaWVudElkOiAiIgogICAgY2xpZW50U2VjcmV0OiAiIgogICAgZW5hYmxlZDogZmFsc2UKICAgIHByb3ZpZGVyOiAiIgogICAgc2NvcGVzOiBbXQogICAgc2VjcmV0UmVmOiAiIgo=
+---
+# Source: policy-reporter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - 'batch'
+  resources:
+  - jobs
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/plugins/kyverno/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-kyverno-plugin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policies
+  - policies/status
+  - clusterpolicies
+  - clusterpolicies/status
+  verbs:
+  - get
+  - list
+---
+# Source: policy-reporter/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter-kyverno-plugin
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter-kyverno-plugin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-kyverno-plugin-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: policy-reporter/templates/ui/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/plugins/kyverno/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-kyverno-plugin-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: Role
+  name: policy-reporter-kyverno-plugin-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: Role
+  name: policy-reporter-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/ui/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: Role
+  name: policy-reporter-ui-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-ui
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/plugins/kyverno/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/ui/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-reporter
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+        app.kubernetes.io/part-of: policy-reporter
+      annotations:
+        checksum/secret: "c4ddd7e3cc5e720b143ba69f57a5db8d468bdf6db53d6d623a19a56b0dee7d5e"
+    spec:
+      serviceAccountName: policy-reporter
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1234
+      containers:
+        - name: policy-reporter
+          image: "ghcr.io/kyverno/policy-reporter:3.0.0-rc.7"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --port=8080
+            - --config=/app/config.yaml
+            - --dbfile=/sqlite/database.db
+            - --metrics-enabled=true
+            - --rest-enabled=true
+            - --profile=false
+            - --lease-name=policy-reporter
+            - --template-dir=/app/templates
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: sqlite
+            mountPath: /sqlite
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: sqlite
+        emptyDir: {}
+      - name: config-file
+        secret:
+          secretName: policy-reporter-config
+          optional: true
+      - name: tmp
+        emptyDir: {}
+---
+# Source: policy-reporter/templates/plugins/kyverno/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter-kyverno-plugin
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-kyverno-plugin
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-kyverno-plugin
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      annotations:
+        checksum/secret: "8f5d41aab81bc2b32e1f7e03600b020809cbb143d897fa663b87a675d7141b32"
+      labels:
+        app.kubernetes.io/name: policy-reporter-kyverno-plugin
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+    spec:
+      serviceAccountName: policy-reporter-kyverno-plugin
+      automountServiceAccountToken: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 1234
+      containers:
+        - name: policy-reporter-kyverno-plugin
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kyverno/policy-reporter/kyverno-plugin:0.4.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --config=/app/config.yaml
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /v1/policies
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /v1/policies
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: config-file
+        secret:
+          secretName: policy-reporter-kyverno-plugin-config
+          optional: true
+---
+# Source: policy-reporter/templates/ui/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-ui
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      annotations:
+        checksum/secret: "c336e3fc53788dec3d2dd67957cdbba64ac9a7d19271f13c51ae6de1b1ede213"
+        checksum/cluster-secret: "103aa626cc0599d7252bb79b0e24738bd359f6231cf85f5bdb8894659099c79f"
+      labels:
+        app.kubernetes.io/name: policy-reporter-ui
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+    spec:
+      serviceAccountName: policy-reporter-ui
+      automountServiceAccountToken: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 1234
+      containers:
+        - name: policy-reporter-ui
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kyverno/policy-reporter-ui:2.0.0-rc.3"
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --config=/app/config.yaml
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: config-file
+        secret:
+          secretName: policy-reporter-ui-config
+          optional: true
+      - name: tmp
+        emptyDir: {}

--- a/manifests/policy-reporter-ui/install.yaml
+++ b/manifests/policy-reporter-ui/install.yaml
@@ -1,0 +1,438 @@
+---
+# Source: policy-reporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+---
+# Source: policy-reporter/templates/ui/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+automountServiceAccountToken: true
+---
+# Source: policy-reporter/templates/cluster-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-default-cluster
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  host: aHR0cDovL3BvbGljeS1yZXBvcnRlcjo4MDgw
+  username: 
+  password:
+---
+# Source: policy-reporter/templates/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  config.yaml: dGFyZ2V0OgogIGxva2k6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICBwYXRoOiAiIgogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGVsYXN0aWNzZWFyY2g6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICB1c2VybmFtZTogIiIKICAgICAgcGFzc3dvcmQ6ICIiCiAgICAgIGFwaUtleTogIiIKICAgICAgaW5kZXg6ICJwb2xpY3ktcmVwb3J0ZXIiCiAgICAgIHJvdGF0aW9uOiAiZGFpbHkiCiAgICAgIHR5cGVsZXNzQXBpOiAiZmFsc2UiCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgc2xhY2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNoYW5uZWw6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAKICAgICAgc2tpcFRMUzogCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZGlzY29yZDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgdGVhbXM6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHdlYmhvb2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHRlbGVncmFtOgogICAgY29uZmlnOgogICAgICBjaGF0SWQ6ICIiCiAgICAgIHRva2VuOiAiIgogICAgICB3ZWJob29rOiAKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZ29vZ2xlQ2hhdDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgczM6CiAgICBjb25maWc6CiAgICAgIGFjY2Vzc0tleUlkOiAKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgCiAgICAgIHJlZ2lvbjogCiAgICAgIGVuZHBvaW50OiAKICAgICAgYnVja2V0OiAKICAgICAgYnVja2V0S2V5RW5hYmxlZDogZmFsc2UKICAgICAga21zS2V5SWQ6IAogICAgICBzZXJ2ZXJTaWRlRW5jcnlwdGlvbjogCiAgICAgIHBhdGhTdHlsZTogZmFsc2UKICAgICAgcHJlZml4OiAKICAgIG5hbWU6IAogICAgc2VjcmV0UmVmOiAiIgogICAgbW91bnRlZFNlY3JldDogIiIKICAgIG1pbmltdW1TZXZlcml0eTogIiIKICAgIHNraXBFeGlzdGluZ09uU3RhcnR1cDogdHJ1ZQoKICBraW5lc2lzOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogCiAgICAgIHNlY3JldEFjY2Vzc0tleTogIAogICAgICByZWdpb246IAogICAgICBlbmRwb2ludDogCiAgICAgIHN0cmVhbU5hbWU6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHNlY3VyaXR5SHViOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogIiIKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgIiIKICAgICAgcmVnaW9uOiAKICAgICAgZW5kcG9pbnQ6IAogICAgICBhY2NvdW50SWQ6ICIiCiAgICAgIHByb2R1Y3ROYW1lOiAKICAgICAgY29tcGFueU5hbWU6IAogICAgICBkZWxheUluU2Vjb25kczogMgogICAgICBzeW5jaHJvbml6ZTogdHJ1ZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGdjczoKICAgIGNvbmZpZzoKICAgICAgY3JlZGVudGlhbHM6IAogICAgICBidWNrZXQ6IAogICAgICBwcmVmaXg6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgp3b3JrZXI6IDUKbWV0cmljczoKICBjdXN0b21MYWJlbHM6IFtdCiAgZW5hYmxlZDogdHJ1ZQogIGZpbHRlcjoge30KICBtb2RlOiBkZXRhaWxlZApzb3VyY2VGaWx0ZXJzOgogIC0gZGlzYWJsZUNsdXN0ZXJSZXBvcnRzOiBmYWxzZQogICAga2luZHM6CiAgICAgIGV4Y2x1ZGU6CiAgICAgIC0gUmVwbGljYVNldAogICAgc2VsZWN0b3I6CiAgICAgIHNvdXJjZToga3l2ZXJubwogICAgdW5jb250cm9sbGVkT25seTogdHJ1ZQoKbGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogZmFsc2UKICByZWxlYXNlT25DYW5jZWw6IHRydWUKICBsZWFzZUR1cmF0aW9uOiAxNQogIHJlbmV3RGVhZGxpbmU6IDEwCiAgcmV0cnlQZXJpb2Q6IDIKcmVkaXM6CiAgYWRkcmVzczogIiIKICBkYXRhYmFzZTogMAogIGVuYWJsZWQ6IGZhbHNlCiAgcGFzc3dvcmQ6ICIiCiAgcHJlZml4OiBwb2xpY3ktcmVwb3J0ZXIKICB1c2VybmFtZTogIiIKCmxvZ2dpbmc6CiAgc2VydmVyOiBmYWxzZQogIGVuY29kaW5nOiBjb25zb2xlCiAgbG9nTGV2ZWw6IDAKCmFwaToKICBiYXNpY0F1dGg6CiAgICB1c2VybmFtZTogCiAgICBwYXNzd29yZDogCiAgICBzZWNyZXRSZWY6IAoKZGF0YWJhc2U6CiAgdHlwZTogCiAgZGF0YWJhc2U6IAogIHVzZXJuYW1lOiAKICBwYXNzd29yZDogCiAgaG9zdDogCiAgZW5hYmxlU1NMOiBmYWxzZQogIGRzbjogCiAgc2VjcmV0UmVmOiAKICBtb3VudGVkU2VjcmV0OiAK
+---
+# Source: policy-reporter/templates/ui/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-ui-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+type: Opaque
+data:
+  config.yaml: bmFtZXNwYWNlOiBwb2xpY3ktcmVwb3J0ZXIKCnRlbXBEaXI6IC90bXAKCmxvZ2dpbmc6CiAgYXBpOiBmYWxzZQogIHNlcnZlcjogZmFsc2UKICBlbmNvZGluZzogY29uc29sZQogIGxvZ0xldmVsOiAwCgpzZXJ2ZXI6CiAgcG9ydDogODA4MAogIGNvcnM6IHRydWUKICBvdmVyd3JpdGVIb3N0OiB0cnVlCgp1aToKICBkaXNwbGF5TW9kZTogCiAgYmFubmVyOiAKCmNsdXN0ZXJzOgogIC0gbmFtZTogRGVmYXVsdAogICAgc2VjcmV0UmVmOiBwb2xpY3ktcmVwb3J0ZXItdWktZGVmYXVsdC1jbHVzdGVyCgpzb3VyY2VzOgogIC0gbmFtZToga3l2ZXJubwogICAgY2hhcnRUeXBlOiByZXN1bHQKICAgIGV4Y2VwdGlvbnM6IGZhbHNlCiAgICBleGNsdWRlczoKICAgICAgcmVzdWx0czoKICAgICAgLSB3YXJuCiAgICAgIC0gZXJyb3IKb3BlbklEQ29ubmVjdDoKICAgIGNhbGxiYWNrVXJsOiAiIgogICAgY2xpZW50SWQ6ICIiCiAgICBjbGllbnRTZWNyZXQ6ICIiCiAgICBkaXNjb3ZlcnlVcmw6ICIiCiAgICBlbmFibGVkOiBmYWxzZQogICAgZ3JvdXBDbGFpbTogIiIKICAgIHNjb3BlczogW10KICAgIHNlY3JldFJlZjogIiIKb2F1dGg6CiAgICBjYWxsYmFja1VybDogIiIKICAgIGNsaWVudElkOiAiIgogICAgY2xpZW50U2VjcmV0OiAiIgogICAgZW5hYmxlZDogZmFsc2UKICAgIHByb3ZpZGVyOiAiIgogICAgc2NvcGVzOiBbXQogICAgc2VjcmV0UmVmOiAiIgo=
+---
+# Source: policy-reporter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - 'batch'
+  resources:
+  - jobs
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: policy-reporter/templates/ui/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: Role
+  name: policy-reporter-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/ui/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-ui-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+roleRef:
+  kind: Role
+  name: policy-reporter-ui-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter-ui
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/ui/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-reporter
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+        app.kubernetes.io/part-of: policy-reporter
+      annotations:
+        checksum/secret: "c4ddd7e3cc5e720b143ba69f57a5db8d468bdf6db53d6d623a19a56b0dee7d5e"
+    spec:
+      serviceAccountName: policy-reporter
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1234
+      containers:
+        - name: policy-reporter
+          image: "ghcr.io/kyverno/policy-reporter:3.0.0-rc.7"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --port=8080
+            - --config=/app/config.yaml
+            - --dbfile=/sqlite/database.db
+            - --metrics-enabled=true
+            - --rest-enabled=true
+            - --profile=false
+            - --lease-name=policy-reporter
+            - --template-dir=/app/templates
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: sqlite
+            mountPath: /sqlite
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: sqlite
+        emptyDir: {}
+      - name: config-file
+        secret:
+          secretName: policy-reporter-config
+          optional: true
+      - name: tmp
+        emptyDir: {}
+---
+# Source: policy-reporter/templates/ui/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter-ui
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter-ui
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter-ui
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      annotations:
+        checksum/secret: "c336e3fc53788dec3d2dd67957cdbba64ac9a7d19271f13c51ae6de1b1ede213"
+        checksum/cluster-secret: "c3b45c82c6b4ac34c9377e93dd20c535bd75df69a485dc50e7704de484c2d86d"
+      labels:
+        app.kubernetes.io/name: policy-reporter-ui
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+    spec:
+      serviceAccountName: policy-reporter-ui
+      automountServiceAccountToken: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 1234
+      containers:
+        - name: policy-reporter-ui
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/kyverno/policy-reporter-ui:2.0.0-rc.3"
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --config=/app/config.yaml
+            - --port=8080
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: config-file
+        secret:
+          secretName: policy-reporter-ui-config
+          optional: true
+      - name: tmp
+        emptyDir: {}

--- a/manifests/policy-reporter/install.yaml
+++ b/manifests/policy-reporter/install.yaml
@@ -1,0 +1,252 @@
+---
+# Source: policy-reporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+---
+# Source: policy-reporter/templates/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-reporter-config
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+type: Opaque
+data:
+  config.yaml: dGFyZ2V0OgogIGxva2k6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICBwYXRoOiAiIgogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGVsYXN0aWNzZWFyY2g6CiAgICBjb25maWc6CiAgICAgIGhvc3Q6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgICB1c2VybmFtZTogIiIKICAgICAgcGFzc3dvcmQ6ICIiCiAgICAgIGFwaUtleTogIiIKICAgICAgaW5kZXg6ICJwb2xpY3ktcmVwb3J0ZXIiCiAgICAgIHJvdGF0aW9uOiAiZGFpbHkiCiAgICAgIHR5cGVsZXNzQXBpOiAiZmFsc2UiCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgc2xhY2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNoYW5uZWw6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAKICAgICAgc2tpcFRMUzogCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZGlzY29yZDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgdGVhbXM6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHdlYmhvb2s6CiAgICBjb25maWc6CiAgICAgIHdlYmhvb2s6ICIiCiAgICAgIGNlcnRpZmljYXRlOiAiIgogICAgICBza2lwVExTOiBmYWxzZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHRlbGVncmFtOgogICAgY29uZmlnOgogICAgICBjaGF0SWQ6ICIiCiAgICAgIHRva2VuOiAiIgogICAgICB3ZWJob29rOiAKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgZ29vZ2xlQ2hhdDoKICAgIGNvbmZpZzoKICAgICAgd2ViaG9vazogIiIKICAgICAgY2VydGlmaWNhdGU6ICIiCiAgICAgIHNraXBUTFM6IGZhbHNlCiAgICBuYW1lOiAKICAgIHNlY3JldFJlZjogIiIKICAgIG1vdW50ZWRTZWNyZXQ6ICIiCiAgICBtaW5pbXVtU2V2ZXJpdHk6ICIiCiAgICBza2lwRXhpc3RpbmdPblN0YXJ0dXA6IHRydWUKCiAgczM6CiAgICBjb25maWc6CiAgICAgIGFjY2Vzc0tleUlkOiAKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgCiAgICAgIHJlZ2lvbjogCiAgICAgIGVuZHBvaW50OiAKICAgICAgYnVja2V0OiAKICAgICAgYnVja2V0S2V5RW5hYmxlZDogZmFsc2UKICAgICAga21zS2V5SWQ6IAogICAgICBzZXJ2ZXJTaWRlRW5jcnlwdGlvbjogCiAgICAgIHBhdGhTdHlsZTogZmFsc2UKICAgICAgcHJlZml4OiAKICAgIG5hbWU6IAogICAgc2VjcmV0UmVmOiAiIgogICAgbW91bnRlZFNlY3JldDogIiIKICAgIG1pbmltdW1TZXZlcml0eTogIiIKICAgIHNraXBFeGlzdGluZ09uU3RhcnR1cDogdHJ1ZQoKICBraW5lc2lzOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogCiAgICAgIHNlY3JldEFjY2Vzc0tleTogIAogICAgICByZWdpb246IAogICAgICBlbmRwb2ludDogCiAgICAgIHN0cmVhbU5hbWU6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIHNlY3VyaXR5SHViOgogICAgY29uZmlnOgogICAgICBhY2Nlc3NLZXlJZDogIiIKICAgICAgc2VjcmV0QWNjZXNzS2V5OiAgIiIKICAgICAgcmVnaW9uOiAKICAgICAgZW5kcG9pbnQ6IAogICAgICBhY2NvdW50SWQ6ICIiCiAgICAgIHByb2R1Y3ROYW1lOiAKICAgICAgY29tcGFueU5hbWU6IAogICAgICBkZWxheUluU2Vjb25kczogMgogICAgICBzeW5jaHJvbml6ZTogdHJ1ZQogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgogIGdjczoKICAgIGNvbmZpZzoKICAgICAgY3JlZGVudGlhbHM6IAogICAgICBidWNrZXQ6IAogICAgICBwcmVmaXg6IAogICAgbmFtZTogCiAgICBzZWNyZXRSZWY6ICIiCiAgICBtb3VudGVkU2VjcmV0OiAiIgogICAgbWluaW11bVNldmVyaXR5OiAiIgogICAgc2tpcEV4aXN0aW5nT25TdGFydHVwOiB0cnVlCgp3b3JrZXI6IDUKbWV0cmljczoKICBjdXN0b21MYWJlbHM6IFtdCiAgZW5hYmxlZDogdHJ1ZQogIGZpbHRlcjoge30KICBtb2RlOiBkZXRhaWxlZApzb3VyY2VGaWx0ZXJzOgogIC0gZGlzYWJsZUNsdXN0ZXJSZXBvcnRzOiBmYWxzZQogICAga2luZHM6CiAgICAgIGV4Y2x1ZGU6CiAgICAgIC0gUmVwbGljYVNldAogICAgc2VsZWN0b3I6CiAgICAgIHNvdXJjZToga3l2ZXJubwogICAgdW5jb250cm9sbGVkT25seTogdHJ1ZQoKbGVhZGVyRWxlY3Rpb246CiAgZW5hYmxlZDogZmFsc2UKICByZWxlYXNlT25DYW5jZWw6IHRydWUKICBsZWFzZUR1cmF0aW9uOiAxNQogIHJlbmV3RGVhZGxpbmU6IDEwCiAgcmV0cnlQZXJpb2Q6IDIKcmVkaXM6CiAgYWRkcmVzczogIiIKICBkYXRhYmFzZTogMAogIGVuYWJsZWQ6IGZhbHNlCiAgcGFzc3dvcmQ6ICIiCiAgcHJlZml4OiBwb2xpY3ktcmVwb3J0ZXIKICB1c2VybmFtZTogIiIKCmxvZ2dpbmc6CiAgc2VydmVyOiBmYWxzZQogIGVuY29kaW5nOiBjb25zb2xlCiAgbG9nTGV2ZWw6IDAKCmFwaToKICBiYXNpY0F1dGg6CiAgICB1c2VybmFtZTogCiAgICBwYXNzd29yZDogCiAgICBzZWNyZXRSZWY6IAoKZGF0YWJhc2U6CiAgdHlwZTogCiAgZGF0YWJhc2U6IAogIHVzZXJuYW1lOiAKICBwYXNzd29yZDogCiAgaG9zdDogCiAgZW5hYmxlU1NMOiBmYWxzZQogIGRzbjogCiAgc2VjcmV0UmVmOiAKICBtb3VudGVkU2VjcmV0OiAK
+---
+# Source: policy-reporter/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - policyreports
+  - policyreports/status
+  - clusterpolicyreports
+  - clusterpolicyreports/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - 'batch'
+  resources:
+  - jobs
+  verbs:
+  - get
+---
+# Source: policy-reporter/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: ClusterRole
+  name: policy-reporter
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/secret-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+rules:
+- apiGroups: ['']
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: policy-reporter/templates/secret-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-reporter-secret-reader
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+roleRef:
+  kind: Role
+  name: policy-reporter-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: "ServiceAccount"
+  name: policy-reporter
+  namespace: policy-reporter
+---
+# Source: policy-reporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+---
+# Source: policy-reporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    app.kubernetes.io/name: policy-reporter
+    app.kubernetes.io/instance: policy-reporter
+    app.kubernetes.io/version: "3.0.0-rc.7"
+    app.kubernetes.io/component: reporting
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: policy-reporter
+      app.kubernetes.io/instance: policy-reporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: policy-reporter
+        app.kubernetes.io/instance: policy-reporter
+        app.kubernetes.io/version: "3.0.0-rc.7"
+        app.kubernetes.io/part-of: policy-reporter
+      annotations:
+        checksum/secret: "c4ddd7e3cc5e720b143ba69f57a5db8d468bdf6db53d6d623a19a56b0dee7d5e"
+    spec:
+      serviceAccountName: policy-reporter
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1234
+      containers:
+        - name: policy-reporter
+          image: "ghcr.io/kyverno/policy-reporter:3.0.0-rc.7"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1234
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --port=8080
+            - --config=/app/config.yaml
+            - --dbfile=/sqlite/database.db
+            - --metrics-enabled=true
+            - --rest-enabled=true
+            - --profile=false
+            - --lease-name=policy-reporter
+            - --template-dir=/app/templates
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {}
+          volumeMounts:
+          - name: sqlite
+            mountPath: /sqlite
+          - name: config-file
+            mountPath: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      volumes:
+      - name: sqlite
+        emptyDir: {}
+      - name: config-file
+        secret:
+          secretName: policy-reporter-config
+          optional: true
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
* Generate static manifests out of the Helm Chart
* Render Monitoring resources only when `monitoring.enabled` is set to `true`