### PR TITLE
Improve helm chart

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -375,7 +375,6 @@ Open `http://localhost:8082/` in your browser.
 | ui.serviceAccount.automount | bool | `true` | Enable ServiceAccount automount |
 | ui.serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | ui.serviceAccount.name | string | `""` | The ServiceAccount name |
-| ui.extraManifests | list | `[]` | list of extra manifests |
 | ui.sidecarContainers | object | `{}` | Add sidecar containers to the UI deployment  sidecarContainers:    oauth-proxy:      image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0      args:      - --upstream=http://127.0.0.1:8080      - --http-address=0.0.0.0:8081      - ...      ports:      - containerPort: 8081        name: oauth-proxy        protocol: TCP      resources: {} |
 | ui.podAnnotations | object | `{}` | Additional annotations to add to each pod |
 | ui.podLabels | object | `{}` | Additional labels to add to each pod |
@@ -590,6 +589,7 @@ Open `http://localhost:8082/` in your browser.
 | monitoring.policyReportOverview.failingTimeline.height | int | `10` |  |
 | monitoring.policyReportOverview.failingPolicyRuleTable.height | int | `10` |  |
 | monitoring.policyReportOverview.failingClusterPolicyRuleTable.height | int | `10` |  |
+| extraManifests | list | `[]` | list of extra manifests |
 
 ## Source Code
 

--- a/charts/policy-reporter/templates/cluster-secret.yaml
+++ b/charts/policy-reporter/templates/cluster-secret.yaml
@@ -15,8 +15,12 @@ data:
   {{- $username := .Values.basicAuth.username }}
   {{- $password := .Values.basicAuth.password }}
   host: {{ printf "http://%s:%d" (include "policyreporter.fullname" .) (.Values.service.port | int) | b64enc }}
-  username: {{ $username | b64enc }}
-  password: {{ $password | b64enc }}
+  {{- if .Values.basicAuth.username }}
+  username: {{ .Values.basicAuth.username | b64enc }}
+  {{- end }}
+  {{- if .Values.basicAuth.password }}
+  password: {{ .Values.basicAuth.password | b64enc }}
+  {{- end }}
   {{- if .Values.plugin.kyverno.enabled }}
   {{- $host := printf "http://%s:%d" (include "kyverno-plugin.fullname" .) (.Values.plugin.kyverno.service.port | int) }}
   plugin.kyverno: {{ (printf "{\"host\":\"%s\", \"name\":\"kyverno\", \"username\":\"%s\", \"password\":\"%s\"}" $host $username $password) | b64enc }}

--- a/charts/policy-reporter/templates/extra-manifests.yaml
+++ b/charts/policy-reporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/charts/policy-reporter/templates/ui/extra-manifests.yaml
+++ b/charts/policy-reporter/templates/ui/extra-manifests.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.ui.enabled -}}
-{{ range .Values.ui.extraManifests }}
----
-{{ tpl . $ }}
-{{ end }}
-{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -986,8 +986,6 @@ ui:
     # -- The ServiceAccount name
     name: ""
 
-  # -- list of extra manifests
-  extraManifests: []
 
   # -- Add sidecar containers to the UI deployment
   #  sidecarContainers:
@@ -1659,3 +1657,6 @@ monitoring:
       height: 10
     failingClusterPolicyRuleTable:
       height: 10
+
+# -- list of extra manifests
+extraManifests: []


### PR DESCRIPTION
Hi, this PR adds two small changes:
- Make extraManifest independant from UI. Sometimes It is necessary to add extra resources like ExternalSecret or IngressRoute even when UI is not needed (Exposing REST API from one cluster to a centralized policy-reporter UI on another cluster)
- Avoid adding empty string `username:` and `password:` to the secret policy-reporter-ui-default-cluster when they are not defined in the values. This causes Argocd to show the app as OutOfSync because kube API removes this field at admission