### PR TITLE
fix: set proper direction for each sortBy param

### DIFF
--- a/pkg/database/builder.go
+++ b/pkg/database/builder.go
@@ -166,11 +166,11 @@ func (q *QueryBuilder) SelectSeveritySummaries() *QueryBuilder {
 }
 
 func (q *QueryBuilder) Pagination(pagination Pagination) *QueryBuilder {
-	q.query.OrderExpr(fmt.Sprintf(
-		"%s %s",
-		strings.Join(pagination.SortBy, ","),
-		pagination.Direction,
-	))
+	sortExpr := []string{}
+	for _, sort := range pagination.SortBy {
+		sortExpr = append(sortExpr, fmt.Sprintf("%s %s", sort, pagination.Direction))
+	}
+	q.query.OrderExpr(strings.Join(sortExpr, ","))
 
 	if pagination.Page == 0 || pagination.Offset == 0 {
 		return q


### PR DESCRIPTION
When multiple sortBy params where defined, direction was only applied to the last one and the previous ones received the DBs default. This change properly applies the direction param to each sortBy param