### PR TITLE
Fix: Fix update target for elasticsearch

### DIFF
--- a/pkg/kubernetes/secrets/informer.go
+++ b/pkg/kubernetes/secrets/informer.go
@@ -79,7 +79,7 @@ func (k *informer) UpdateTarget(t *target.Target, secret string) *target.Target 
 	case target.Loki:
 		updatedTarget = createClients(t.Config, t.ParentConfig, k.factory.CreateLokiTarget)
 	case target.Elasticsearch:
-		updatedTarget = createClients(t.Config, t.ParentConfig, k.factory.CreateLokiTarget)
+		updatedTarget = createClients(t.Config, t.ParentConfig, k.factory.CreateElasticsearchTarget)
 	case target.Slack:
 		updatedTarget = createClients(t.Config, t.ParentConfig, k.factory.CreateSlackTarget)
 	case target.Discord:


### PR DESCRIPTION
### Fix panic error

## Problem
**Policy report pod keeps restarting on the cluster due to a panic error:**

` E0227 07:02:23.007662       1 iface.go:275] "Observed a panic" panic="interface conversion: interface {} is *target.Config[github.com/kyverno/policy-reporter/pkg/target.ElasticsearchOptions], not *target.Config[github.com/kyverno/policy-reporter/pkg/target.LokiOptions]" panicGoValue="&runtime.TypeAssertionError{_interface:(*abi.Type)(0x2f38b00), concrete:(*abi.Type)(0x3074400), asserted:(*abi.Type)(0x3074580), missingMethod:\"\"}" stacktrace=<
	goroutine 57 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3a523c0, 0x56fa400}, {0x3009600, 0xc00070d200})
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:107 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x3a523c0, 0x56fa400}, {0x3009600, 0xc00070d200}, {0x56fa400, 0x0, 0x4427d8?})
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:82 +0x5a
	k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0004fd6c0?})
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:59 +0x105
	panic({0x3009600?, 0xc00070d200?})
		/usr/local/go/src/runtime/panic.go:787 +0x132
	github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.createClients[...](...)
		/app/pkg/kubernetes/secrets/informer.go:121
	github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.(*informer).UpdateTarget(0xc0004f82d0?, 0xc0004f82d0, {0xc0008c3d60?, 0x2f38b00?})
		/app/pkg/kubernetes/secrets/informer.go:82 +0x865
	github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.(*informer).configureInformer.func1({0x413232?, 0xc0004ac9a0?}, {0x34e07c0?, 0xc0004d0480?})
		/app/pkg/kubernetes/secrets/informer.go:62 +0x21e
	k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
		/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/controller.go:253
	k8s.io/client-go/tools/cache.(*processorListener).run.func1()
		/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/shared_informer.go:976 +0x16c
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0000a5008?)
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:226 +0x33
	k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0008f6f70, {0x3a0e2c0, 0xc0008eec30}, 0x1, 0xc0004ad810)
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:227 +0xaf
	k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0008c3f70, 0x3b9aca00, 0x0, 0x1, 0xc0004ad810)
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:204 +0x7f
	k8s.io/apimachinery/pkg/util/wait.Until(...)
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:161
	k8s.io/client-go/tools/cache.(*processorListener).run(0xc0004be870)
		/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/shared_informer.go:972 +0x5a
	k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/wait.go:72 +0x4c
	created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 40
		/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/wait.go:70 +0x73
 >
panic: interface conversion: interface {} is *target.Config[github.com/kyverno/policy-reporter/pkg/target.ElasticsearchOptions], not *target.Config[github.com/kyverno/policy-reporter/pkg/target.LokiOptions] [recovered]
	panic: interface conversion: interface {} is *target.Config[github.com/kyverno/policy-reporter/pkg/target.ElasticsearchOptions], not *target.Config[github.com/kyverno/policy-reporter/pkg/target.LokiOptions]

goroutine 57 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x3a523c0, 0x56fa400}, {0x3009600, 0xc00070d200}, {0x56fa400, 0x0, 0x4427d8?})
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:89 +0xe7
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0004fd6c0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/runtime/runtime.go:59 +0x105
panic({0x3009600?, 0xc00070d200?})
	/usr/local/go/src/runtime/panic.go:787 +0x132
github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.createClients[...](...)
	/app/pkg/kubernetes/secrets/informer.go:121
github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.(*informer).UpdateTarget(0xc0004f82d0?, 0xc0004f82d0, {0xc0008c3d60?, 0x2f38b00?})
	/app/pkg/kubernetes/secrets/informer.go:82 +0x865
github.com/kyverno/policy-reporter/pkg/kubernetes/secrets.(*informer).configureInformer.func1({0x413232?, 0xc0004ac9a0?}, {0x34e07c0?, 0xc0004d0480?})
	/app/pkg/kubernetes/secrets/informer.go:62 +0x21e
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/controller.go:253
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/shared_informer.go:976 +0x16c
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0000a5008?)
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc000085f70, {0x3a0e2c0, 0xc0008eec30}, 0x1, 0xc0004ad810)
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0008c3f70, 0x3b9aca00, 0x0, 0x1, 0xc0004ad810)
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/backoff.go:161
k8s.io/client-go/tools/cache.(*processorListener).run(0xc0004be870)
	/go/pkg/mod/k8s.io/client-go@v0.32.2/tools/cache/shared_informer.go:972 +0x5a
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/wait.go:72 +0x4c
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 40
	/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/util/wait/wait.go:70 +0x73
`

## Solution
The elasticsearch update target function was incorrectly pointing to loki.