### PR TITLE
Add support for additional Trivy arguments in deployment configuration

### DIFF
--- a/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
@@ -47,6 +47,11 @@ spec:
           - /
           - image
           - --download-db-only
+          {{- range $key, $value := .Values.plugin.trivy.extraArgs }}
+          {{- if $value }}
+          - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- end }}
           securityContext:
           {{- if .Values.plugin.trivy.securityContext }}
             {{- toYaml .Values.plugin.trivy.securityContext | nindent 12 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1386,6 +1386,9 @@ plugin:
           # Defaults to `Chart.AppVersion` if omitted
         tag: "0.58.2"
 
+    # -- Additional container args.
+    extraArgs: {}
+
     github:
       # -- (string) optional github token for authenticated GitHub API calls.
       token: ""


### PR DESCRIPTION
Specifically I want to configure Trivy to download databases from alternative locations by using the flags:

--db-repository

to point at my local registry.