### PR TITLE
fix: replace status with severity to fix errors when sending to discord

### DIFF
--- a/pkg/target/discord/discord.go
+++ b/pkg/target/discord/discord.go
@@ -37,13 +37,16 @@ type embedField struct {
 var colors = map[v1alpha2.PolicySeverity]string{
 	v1alpha2.SeverityInfo:     "12370112",
 	v1alpha2.SeverityLow:      "3066993",
-	v1alpha2.StatusWarn:       "15105570",
+	v1alpha2.SeverityMedium:   "15105570",
 	v1alpha2.SeverityHigh:     "15158332",
 	v1alpha2.SeverityCritical: "15158332",
 }
 
 func newPayload(result v1alpha2.PolicyReportResult, customFields map[string]string) payload {
-	color := colors[result.Severity]
+	color, exists := colors[result.Severity]
+	if !exists {
+		color = "0"
+	}
 
 	embedFields := make([]embedField, 0)
 


### PR DESCRIPTION
Fixes #825 and ensures that if something still does not match the [default color "0"](https://gist.github.com/thomasbnt/b6f455e2c7d743b796917fa3c205f812) is used since go returns "" for string maps.