### PR TITLE
feat: Create Splunk target implementation and CRD

### DIFF
--- a/config/crds/policyreporter.kyverno.io_targetconfigs.yaml
+++ b/config/crds/policyreporter.kyverno.io_targetconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.0.0-20250310082807-ee11c57ea31a+dirty
+    controller-gen.kubebuilder.io/version: (devel)
   name: targetconfigs.policyreporter.kyverno.io
 spec:
   group: policyreporter.kyverno.io
@@ -59,6 +59,8 @@ spec:
               - securityHub
             - required:
               - kinesis
+            - required:
+              - splunk
             - required:
               - teams
             - required:
@@ -344,6 +346,24 @@ spec:
                 items:
                   type: string
                 type: array
+              splunk:
+                properties:
+                  certificate:
+                    type: string
+                  headers:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  host:
+                    type: string
+                  skipTLS:
+                    type: boolean
+                  token:
+                    type: string
+                required:
+                - host
+                - token
+                type: object
               teams:
                 properties:
                   certificate:

--- a/pkg/api/v2/api.go
+++ b/pkg/api/v2/api.go
@@ -281,6 +281,6 @@ func NewAPIHandler(store *db.Store, client namespaces.Client, targets map[string
 
 func WithAPI(store *db.Store, client namespaces.Client, targets target.Targets) api.ServerOption {
 	return func(s *api.Server) error {
-		return s.Register("v2", NewAPIHandler(store, client, MapConfigTagrgets(targets)))
+		return s.Register("v2", NewAPIHandler(store, client, MapConfigTargets(targets)))
 	}
 }

--- a/pkg/api/v2/views.go
+++ b/pkg/api/v2/views.go
@@ -693,6 +693,14 @@ func MapSecurityHubToTarget(ta *v1alpha1.Config[v1alpha1.SecurityHubOptions]) *T
 	return t
 }
 
+func MapSplunkToTarget(ta *v1alpha1.Config[v1alpha1.SplunkOptions]) *Target {
+	t := MapBaseToTarget(ta)
+
+	t.Type = "Splunk"
+	t.Properties["host"] = ta.Config.Host
+	return t
+}
+
 func MapGCSToTarget(ta *v1alpha1.Config[v1alpha1.GCSOptions]) *Target {
 	t := MapBaseToTarget(ta)
 	t.Type = "GoogleCloudStore"
@@ -737,7 +745,7 @@ func MapTargets[T any](c *v1alpha1.Config[T], mapper func(*v1alpha1.Config[T]) *
 	return targets
 }
 
-func MapConfigTagrgets(c target.Targets) map[string][]*Target {
+func MapConfigTargets(c target.Targets) map[string][]*Target {
 	targets := make(map[string][]*Target)
 
 	targets["loki"] = MapTargets(c.Loki, MapLokiToTarget)
@@ -753,6 +761,7 @@ func MapConfigTagrgets(c target.Targets) map[string][]*Target {
 	targets["securityHub"] = MapTargets(c.SecurityHub, MapSecurityHubToTarget)
 	targets["gcs"] = MapTargets(c.GCS, MapGCSToTarget)
 	targets["alertManager"] = MapTargets(c.AlertManager, MapAlertManagerToTarget)
+	targets["splunk"] = MapTargets(c.Splunk, MapSplunkToTarget)
 
 	for k, v := range targets {
 		if len(v) == 0 {

--- a/pkg/crd/api/targetconfig/v1alpha1/configs.go
+++ b/pkg/crd/api/targetconfig/v1alpha1/configs.go
@@ -69,6 +69,12 @@ type SlackOptions struct {
 	Channel        string `mapstructure:"channel" json:"channel"`
 }
 
+type SplunkOptions struct {
+	HostOptions `mapstructure:",squash" json:",inline"`
+
+	Token string `mapstructure:"token" json:"token"`
+}
+
 type LokiOptions struct {
 	HostOptions `mapstructure:",squash" json:",inline"`
 	// +optional

--- a/pkg/crd/api/targetconfig/v1alpha1/targetconfig_types.go
+++ b/pkg/crd/api/targetconfig/v1alpha1/targetconfig_types.go
@@ -29,6 +29,7 @@ import (
 // +kubebuilder:oneOf:={required:{loki}}
 // +kubebuilder:oneOf:={required:{securityHub}}
 // +kubebuilder:oneOf:={required:{kinesis}}
+// +kubebuilder:oneOf:={required:{splunk}}
 // +kubebuilder:oneOf:={required:{teams}}
 // +kubebuilder:oneOf:={required:{jira}}
 // +kubebuilder:oneOf:={required:{alertManager}}
@@ -72,6 +73,9 @@ type TargetConfigSpec struct {
 
 	// +optional
 	AlertManager *AlertManagerOptions `json:"alertManager,omitempty"`
+
+	// +optional
+	Splunk *SplunkOptions `json:"splunk,omitempty"`
 }
 
 // TargetConfigStatus defines the observed state of TargetConfig.

--- a/pkg/target/collection.go
+++ b/pkg/target/collection.go
@@ -47,6 +47,7 @@ type Targets struct {
 	SecurityHub   *v1alpha1.Config[v1alpha1.SecurityHubOptions]   `mapstructure:"securityHub"`
 	GCS           *v1alpha1.Config[v1alpha1.GCSOptions]           `mapstructure:"gcs"`
 	AlertManager  *v1alpha1.Config[v1alpha1.AlertManagerOptions]  `mapstructure:"alertManager"`
+	Splunk        *v1alpha1.Config[v1alpha1.SplunkOptions]        `mapstructure:"splunk"`
 }
 
 type TargetConfig interface {

--- a/pkg/target/collection.go
+++ b/pkg/target/collection.go
@@ -29,6 +29,7 @@ const (
 	SecurityHub   TargetType = "SecurityHub"
 	GCS           TargetType = "GCS"
 	AlertManager  TargetType = "AlertManager"
+	Splunk        TargetType = "Splunk"
 )
 
 type Targets struct {

--- a/pkg/target/factory.go
+++ b/pkg/target/factory.go
@@ -20,4 +20,5 @@ type Factory interface {
 	CreateKinesisTarget(config, parent *v1alpha1.Config[v1alpha1.KinesisOptions]) *Target
 	CreateSecurityHubTarget(config, parent *v1alpha1.Config[v1alpha1.SecurityHubOptions]) *Target
 	CreateGCSTarget(config, parent *v1alpha1.Config[v1alpha1.GCSOptions]) *Target
+	CreateSplunkTarget(config, parent *v1alpha1.Config[v1alpha1.SplunkOptions]) *Target
 }

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -1008,6 +1008,14 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 			c.Config.Channel = values.Channel
 		}
 
+	case *v1alpha1.Config[v1alpha1.SplunkOptions]:
+		if values.Webhook != "" {
+			c.Config.Host = values.Host
+		}
+		if values.Channel != "" {
+			c.Config.Token = values.Token
+		}
+
 	case *v1alpha1.Config[v1alpha1.WebhookOptions]:
 		if values.Webhook != "" {
 			c.Config.Webhook = values.Webhook

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/target/s3"
 	"github.com/kyverno/policy-reporter/pkg/target/securityhub"
 	"github.com/kyverno/policy-reporter/pkg/target/slack"
+	"github.com/kyverno/policy-reporter/pkg/target/splunk"
 	"github.com/kyverno/policy-reporter/pkg/target/teams"
 	"github.com/kyverno/policy-reporter/pkg/target/telegram"
 	"github.com/kyverno/policy-reporter/pkg/target/webhook"
@@ -137,6 +138,8 @@ func (f *TargetFactory) CreateSingleClient(tc *v1alpha1.TargetConfig) (*target.T
 		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Teams), f.CreateTeamsTarget))
 	case tc.Spec.Jira != nil:
 		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Jira), f.CreateJiraTarget))
+	case tc.Spec.Splunk != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Splunk), f.CreateSplunkTarget))
 	default:
 		return nil, fmt.Errorf("invalid target type passed")
 	}
@@ -192,6 +195,46 @@ func (f *TargetFactory) CreateSlackTarget(config, parent *v1alpha1.Config[v1alph
 			CustomFields: config.CustomFields,
 			Headers:      config.Config.Headers,
 			HTTPClient:   http.NewClient("", false),
+		}),
+	}
+}
+
+func (f *TargetFactory) CreateSplunkTarget(config, parent *v1alpha1.Config[v1alpha1.SplunkOptions]) *target.Target {
+	if config == nil {
+		return nil
+	}
+
+	if (parent.SecretRef != "" && f.secretClient != nil) || parent.MountedSecret != "" {
+		f.mapSecretValues(parent, parent.SecretRef, parent.MountedSecret)
+	}
+
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(config, config.SecretRef, config.MountedSecret)
+	}
+
+	if config.Config.Token == "" && config.Config.Host == "" {
+		return nil
+	}
+
+	config.Config.Headers = make(map[string]string)
+	config.Config.Headers["Authorization"] = "Splunk " + config.Config.Token
+
+	return &target.Target{
+		ID:           uuid.NewString(),
+		Type:         target.Splunk,
+		Config:       config,
+		ParentConfig: parent,
+		Client: splunk.NewClient(splunk.Options{
+			ClientOptions: target.ClientOptions{
+				Name:                  config.Name,
+				SkipExistingOnStartup: config.SkipExisting,
+				ResultFilter:          f.createResultFilter(config.Filter, config.MinimumSeverity, config.Sources),
+				ReportFilter:          createReportFilter(config.Filter),
+			},
+			Headers:    config.Config.Headers,
+			HTTPClient: http.NewClient(config.Config.Certificate, config.Config.SkipTLS),
+			Host:       config.Config.Host,
+			Token:      config.Config.Token,
 		}),
 	}
 }

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -100,6 +100,7 @@ func (f *TargetFactory) CreateClients(config *target.Targets) *target.Collection
 	targets = append(targets, createClients("SecurityHub", config.SecurityHub, f.CreateSecurityHubTarget)...)
 	targets = append(targets, createClients("GoogleCloudStorage", config.GCS, f.CreateGCSTarget)...)
 	targets = append(targets, createClients("AlertManager", config.AlertManager, f.CreateAlertManagerTarget)...)
+	targets = append(targets, createClients("Splunk", config.Splunk, f.CreateSplunkTarget)...)
 
 	collection := target.NewCollection(targets...)
 
@@ -1009,7 +1010,7 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 		}
 
 	case *v1alpha1.Config[v1alpha1.SplunkOptions]:
-		if values.Webhook != "" {
+		if values.Host != "" {
 			c.Config.Host = values.Host
 		}
 		if values.Channel != "" {

--- a/pkg/target/splunk/splunk.go
+++ b/pkg/target/splunk/splunk.go
@@ -1,10 +1,11 @@
 package splunk
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
 	"github.com/kyverno/policy-reporter/pkg/target"
 	"github.com/kyverno/policy-reporter/pkg/target/http"
-	"go.uber.org/zap"
 )
 
 const policyReporterSource = "Policy-Reporter"

--- a/pkg/target/splunk/splunk.go
+++ b/pkg/target/splunk/splunk.go
@@ -1,6 +1,8 @@
 package splunk
 
 import (
+	"encoding/json"
+
 	"go.uber.org/zap"
 
 	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
@@ -41,13 +43,17 @@ func (c *client) Send(result v1alpha2.PolicyReportResult) {
 }
 
 func (c *client) BatchSend(rep v1alpha2.ReportInterface, results []v1alpha2.PolicyReportResult) {
-	srs := []splunkRequest{}
+	srs := ""
 	for _, res := range results {
 		sr := splunkRequest{
 			Event:      http.NewJSONResult(res),
 			SourceType: policyReporterSource,
 		}
-		srs = append(srs, sr)
+		srString, err := json.Marshal(sr)
+		if err != nil {
+
+		}
+		srs = srs + string(srString)
 	}
 
 	c.sendAndLogResult(srs)

--- a/pkg/target/splunk/splunk.go
+++ b/pkg/target/splunk/splunk.go
@@ -51,7 +51,8 @@ func (c *client) BatchSend(rep v1alpha2.ReportInterface, results []v1alpha2.Poli
 		}
 		srString, err := json.Marshal(sr)
 		if err != nil {
-
+			zap.L().Error(c.Name()+"Error marhsalling the JSON to a splunk request:", zap.Error(err))
+			return
 		}
 		srs = srs + string(srString)
 	}

--- a/pkg/target/splunk/splunk.go
+++ b/pkg/target/splunk/splunk.go
@@ -1,0 +1,70 @@
+package splunk
+
+import (
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/http"
+	"go.uber.org/zap"
+)
+
+const policyReporterSource = "Policy-Reporter"
+
+type splunkRequest struct {
+	Event      http.Result `json:"event"`
+	SourceType string      `json:"sourcetype"`
+}
+
+type Options struct {
+	target.ClientOptions
+	Host         string
+	CustomFields map[string]string
+	HTTPClient   http.Client
+	Headers      map[string]string
+	Token        string
+}
+
+type client struct {
+	target.BaseClient
+	host         string
+	customFields map[string]string
+	headers      map[string]string
+	client       http.Client
+	token        string
+}
+
+func (c *client) Send(result v1alpha2.PolicyReportResult) {
+	sr := splunkRequest{
+		Event:      http.NewJSONResult(result),
+		SourceType: policyReporterSource,
+	}
+
+	req, err := http.CreateJSONRequest("POST", c.host, sr)
+	if err != nil {
+		zap.L().Error(c.Name()+": PUSH FAILED", zap.Error(err))
+		return
+	}
+
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.client.Do(req)
+
+	http.ProcessHTTPResponse(c.Name(), resp, err)
+	zap.L().Info(c.Name() + ": PUSH OK")
+}
+
+func (c *client) Type() string {
+	return target.SingleSend
+}
+
+func NewClient(options Options) target.Client {
+	return &client{
+		target.NewBaseClient(options.ClientOptions),
+		options.Host,
+		options.CustomFields,
+		options.Headers,
+		options.HTTPClient,
+		options.Token,
+	}
+}

--- a/pkg/target/splunk/splunk_test.go
+++ b/pkg/target/splunk/splunk_test.go
@@ -1,0 +1,52 @@
+package splunk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/kyverno/policy-reporter/pkg/fixtures"
+	"github.com/kyverno/policy-reporter/pkg/target"
+)
+
+type testClient struct {
+	callBack   func(req *http.Request) error
+	statusCode int
+}
+
+func (c testClient) Do(req *http.Request) (*http.Response, error) {
+	err := c.callBack(req)
+	return &http.Response{
+		StatusCode: c.statusCode,
+	}, err
+}
+
+func TestSplunkTarget(t *testing.T) {
+	t.Run("Send", func(t *testing.T) {
+		callback := func(req *http.Request) error {
+			if agent := req.Header.Get("User-Agent"); agent != "Policy-Reporter" {
+				t.Errorf("Unexpected Agent: %s", agent)
+			}
+
+			if url := req.URL.String(); url != "http://localhost:8088/services/collector" {
+				t.Errorf("Unexpected Host: %s", url)
+			}
+
+			if value := req.Header.Get("Authorization"); value != "Splunk my-token" {
+				t.Errorf("Unexpected Header Authorization: %s", value)
+			}
+
+			return nil
+		}
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "Test",
+			},
+			Host:       "http://localhost:8088/services/collector",
+			Token:      "my-token",
+			Headers:    map[string]string{"Authorization": "Splunk my-token"},
+			HTTPClient: testClient{callback, 200},
+		})
+		client.Send(fixtures.CompleteTargetSendResult)
+	})
+}


### PR DESCRIPTION
Users who want to consume the splunk target will need to use splunk HTTP Event Collector (HEC) in their instances