### PR TITLE
Enable configuration of topologySpreadConstraints for plugins

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -480,6 +480,7 @@ Open `http://localhost:8082/` in your browser.
 | plugin.kyverno.nodeSelector | object | `{}` | Node labels for pod assignment |
 | plugin.kyverno.tolerations | list | `[]` | List of node taints to tolerate |
 | plugin.kyverno.affinity | object | `{}` | Affinity constraints. |
+| plugin.kyverno.topologySpreadConstraints | object | `{}` | Pod Topology Spread Constraints for the kyverno plugin. |
 | plugin.kyverno.extraVolumes.volumeMounts | list | `[]` | Deployment volumeMounts |
 | plugin.kyverno.extraVolumes.volumes | list | `[]` | Deployment values |
 | plugin.trivy.enabled | bool | `false` | Enable Trivy Operator Plugin |
@@ -544,6 +545,7 @@ Open `http://localhost:8082/` in your browser.
 | plugin.trivy.nodeSelector | object | `{}` | Node labels for pod assignment |
 | plugin.trivy.tolerations | list | `[]` | List of node taints to tolerate |
 | plugin.trivy.affinity | object | `{}` | Affinity constraints. |
+| plugin.trivy.topologySpreadConstraints | object | `{}` | Pod Topology Spread Constraints for the trivy plugin. |
 | plugin.trivy.extraVolumes.volumeMounts | list | `[]` | Deployment volumeMounts |
 | plugin.trivy.extraVolumes.volumes | list | `[]` | Deployment values |
 | monitoring.enabled | bool | `false` | Enables the Prometheus Operator integration |

--- a/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/deployment.yaml
@@ -103,6 +103,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.plugin.kyverno.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.plugin.kyverno.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
+++ b/charts/policy-reporter/templates/plugins/trivy/deployment.yaml
@@ -129,6 +129,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.plugin.trivy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.plugin.trivy.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1359,8 +1359,11 @@ plugin:
     # -- List of node taints to tolerate
     tolerations: []
 
-      # -- Affinity constraints.
+    # -- Affinity constraints.
     affinity: {}
+
+    # -- Pod Topology Spread Constraints for the kyverno plugin.
+    topologySpreadConstraints: {}
 
     extraVolumes:
       # -- Deployment volumeMounts
@@ -1582,8 +1585,11 @@ plugin:
     # -- List of node taints to tolerate
     tolerations: []
 
-      # -- Affinity constraints.
+    # -- Affinity constraints.
     affinity: {}
+
+    # -- Pod Topology Spread Constraints for the trivy plugin.
+    topologySpreadConstraints: {}
 
     extraVolumes:
       # -- Deployment volumeMounts


### PR DESCRIPTION
Extending helmchart to enable configuration of topologySpreadConstraints for kyverno and trivy plugins