### PR TITLE
feat: add AlertManager target implementation 

### DIFF
--- a/config/crds/policyreporter.kyverno.io_targetconfigs.yaml
+++ b/config/crds/policyreporter.kyverno.io_targetconfigs.yaml
@@ -61,7 +61,30 @@ spec:
               - kinesis
             - required:
               - teams
+            - required:
+              - alertManager
             properties:
+              alertManager:
+                properties:
+                  host:
+                    type: string
+                  headers:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  skipTLS:
+                    type: boolean
+                  certificate:
+                    type: string
+                  minimumSeverity:
+                    type: string
+                  sources:
+                    type: array
+                    items:
+                      type: string
+                required:
+                - host
+                type: object
               customFields:
                 additionalProperties:
                   type: string

--- a/docs/ALERTMANAGER_TARGET.md
+++ b/docs/ALERTMANAGER_TARGET.md
@@ -1,0 +1,119 @@
+# AlertManager Integration
+
+This document explains how to set up the AlertManager integration with Policy Reporter to receive policy violation alerts.
+
+## Overview
+
+The AlertManager integration allows Policy Reporter to send policy violation notifications to AlertManager, which can then route and manage alerts based on its own configuration. This integration enables you to:
+
+- Monitor and get notified about Kubernetes policy violations
+- Route alerts to different notification channels (email, Slack, etc.) based on severity, source, or other criteria
+- Use AlertManager's features like silencing, grouping, and inhibition for policy violation alerts
+
+## Configuration
+
+### 1. Policy Reporter TargetConfig
+
+Create a TargetConfig to connect Policy Reporter to AlertManager:
+
+```yaml
+apiVersion: policyreporter.kyverno.io/v1alpha1
+kind: TargetConfig
+metadata:
+  name: alertmanager-target
+spec:
+  alertManager:
+    host: http://alertmanager.monitoring:9093
+    skipTLS: true
+    minimumSeverity: warning
+    sources:
+      - kyverno
+      - policy-reporter
+```
+
+Configuration options:
+
+| Option | Description | Required | Default |
+|--------|-------------|----------|---------|
+| `host` | URL of the AlertManager API | Yes | - |
+| `skipTLS` | Skip TLS verification | No | `false` |
+| `certificate` | Path to custom certificate | No | - |
+| `minimumSeverity` | Minimum severity level to send (info, warning, error, critical) | No | - |
+| `sources` | List of sources to accept alerts from | No | All sources |
+| `headers` | Custom HTTP headers | No | - |
+
+### 2. AlertManager Configuration
+
+Configure AlertManager to receive and properly route the alerts:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+data:
+  alertmanager.yml: |
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['alertname', 'severity', 'policy', 'rule', 'source']
+      group_wait: 10s
+      group_interval: 10s
+      repeat_interval: 1h
+      receiver: 'default'
+    receivers:
+    - name: 'default'
+      webhook_configs:
+      - url: 'http://your-webhook-endpoint'
+        send_resolved: true
+```
+
+## Alert Format
+
+Policy Reporter sends alerts to AlertManager with the following structure:
+
+### Labels
+
+- `alertname`: "PolicyReporterViolation"
+- `severity`: The policy severity (info, warning, medium, high, critical)
+- `status`: The result status (pass, fail, warn, error, skip)
+- `source`: The policy source (kyverno, policy-reporter, etc.)
+- `policy`: The policy name
+- `rule`: The rule name
+
+### Annotations
+
+- `message`: The violation message
+- `category`: The policy category (if available)
+- `resource`: The resource string (namespace/kind/name)
+- `resource_kind`: The resource kind
+- `resource_name`: The resource name
+- `resource_namespace`: The resource namespace
+- `resource_apiversion`: The resource API version
+
+Additional properties from the policy result are also included as annotations.
+
+## Verification
+
+After setting up the integration, verify it's working by:
+
+1. Port-forwarding to the AlertManager service:
+   ```bash
+   kubectl port-forward svc/alertmanager -n monitoring 9093:9093
+   ```
+
+2. Accessing the AlertManager UI at http://localhost:9093
+
+3. Checking for alerts via the API:
+   ```bash
+   curl -s http://localhost:9093/api/v2/alerts | jq
+   ```
+
+## Troubleshooting
+
+If you're not seeing alerts in AlertManager:
+
+1. Verify the TargetConfig is correctly configured and applied
+2. Check Policy Reporter logs for any errors when sending alerts
+3. Ensure AlertManager is accessible from the Policy Reporter pod
+4. Verify the AlertManager configuration has the correct receiver setup 

--- a/pkg/api/v2/views.go
+++ b/pkg/api/v2/views.go
@@ -703,6 +703,20 @@ func MapGCSToTarget(ta *v1alpha1.Config[v1alpha1.GCSOptions]) *Target {
 	return t
 }
 
+func MapAlertManagerToTarget(ta *v1alpha1.Config[v1alpha1.AlertManagerOptions]) *Target {
+	t := MapBaseToTarget(ta)
+	t.Type = "AlertManager"
+	t.Host = ta.Config.Host
+	t.SkipTLS = ta.Config.SkipTLS
+	t.UseTLS = ta.Config.Certificate != ""
+
+	if v, ok := ta.Config.Headers["Authorization"]; ok && v != "" {
+		t.Auth = true
+	}
+
+	return t
+}
+
 func MapTargets[T any](c *v1alpha1.Config[T], mapper func(*v1alpha1.Config[T]) *Target) []*Target {
 	targets := make([]*Target, 0)
 
@@ -738,6 +752,7 @@ func MapConfigTagrgets(c target.Targets) map[string][]*Target {
 	targets["kinesis"] = MapTargets(c.Kinesis, MapKinesisToTarget)
 	targets["securityHub"] = MapTargets(c.SecurityHub, MapSecurityHubToTarget)
 	targets["gcs"] = MapTargets(c.GCS, MapGCSToTarget)
+	targets["alertManager"] = MapTargets(c.AlertManager, MapAlertManagerToTarget)
 
 	for k, v := range targets {
 		if len(v) == 0 {

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -10,6 +10,8 @@ import (
 
 func Load(cmd *cobra.Command) (*Config, error) {
 	v := viper.New()
+	v.SetConfigType("yaml") // Set config type explicitly
+	v.SetConfigFile("")     // Don't watch for file changes
 
 	v.SetDefault("leaderElection.releaseOnCancel", true)
 	v.SetDefault("leaderElection.leaseDuration", 15)

--- a/pkg/crd/api/targetconfig/v1alpha1/configs.go
+++ b/pkg/crd/api/targetconfig/v1alpha1/configs.go
@@ -187,3 +187,15 @@ func (config *AWSConfig) MapAWSParent(parent AWSConfig) {
 		config.Region = parent.Region
 	}
 }
+
+// AlertManagerOptions defines the configuration for AlertManager target
+type AlertManagerOptions struct {
+	// Host of the AlertManager instance
+	Host string `json:"host"`
+	// Headers to add to each request
+	Headers map[string]string `json:"headers,omitempty"`
+	// Skip TLS verification
+	SkipTLS bool `json:"skipTLS,omitempty"`
+	// Certificate for TLS verification
+	Certificate string `json:"certificate,omitempty"`
+}

--- a/pkg/crd/api/targetconfig/v1alpha1/targetconfig_types.go
+++ b/pkg/crd/api/targetconfig/v1alpha1/targetconfig_types.go
@@ -31,6 +31,8 @@ import (
 // +kubebuilder:oneOf:={required:{kinesis}}
 // +kubebuilder:oneOf:={required:{teams}}
 // +kubebuilder:oneOf:={required:{jira}}
+// +kubebuilder:oneOf:={required:{alertManager}}
+
 // TargetConfigSpec defines the desired state of TargetConfig.
 type TargetConfigSpec struct {
 	ConfigStrict `json:",inline"`
@@ -67,6 +69,9 @@ type TargetConfigSpec struct {
 
 	// +optional
 	Jira *JiraOptions `json:"jira,omitempty"`
+
+	// +optional
+	AlertManager *AlertManagerOptions `json:"alertManager,omitempty"`
 }
 
 // TargetConfigStatus defines the observed state of TargetConfig.

--- a/pkg/target/alertmanager/alertmanager.go
+++ b/pkg/target/alertmanager/alertmanager.go
@@ -1,0 +1,220 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	targethttp "github.com/kyverno/policy-reporter/pkg/target/http"
+)
+
+// Alert represents an AlertManager alert
+type Alert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    time.Time         `json:"startsAt"`
+	EndsAt      time.Time         `json:"endsAt"`
+}
+
+// Options to configure the AlertManager target
+type Options struct {
+	target.ClientOptions
+	Host         string
+	Headers      map[string]string
+	CustomFields map[string]string
+	HTTPClient   targethttp.Client
+}
+
+type client struct {
+	target.BaseClient
+	host         string
+	headers      map[string]string
+	customFields map[string]string
+	client       targethttp.Client
+}
+
+func (a *client) Send(result v1alpha2.PolicyReportResult) {
+	zap.L().Info("Sending policy violation to AlertManager",
+		zap.String("policy", result.Policy),
+		zap.String("rule", result.Rule),
+		zap.String("severity", string(result.Severity)),
+		zap.String("status", string(result.Result)),
+		zap.String("source", result.Source),
+		zap.String("message", result.Message))
+
+	alert := a.createAlert(result)
+	a.sendAlerts([]Alert{alert})
+}
+
+func (a *client) BatchSend(report v1alpha2.ReportInterface, results []v1alpha2.PolicyReportResult) {
+	zap.L().Info("Batch sending policy violations to AlertManager",
+		zap.Int("count", len(results)),
+		zap.String("reportName", report.GetName()),
+		zap.String("reportNamespace", report.GetNamespace()))
+
+	alerts := make([]Alert, 0, len(results))
+	for _, result := range results {
+		zap.L().Debug("Processing policy violation for AlertManager",
+			zap.String("policy", result.Policy),
+			zap.String("rule", result.Rule),
+			zap.String("severity", string(result.Severity)),
+			zap.String("status", string(result.Result)),
+			zap.String("source", result.Source))
+
+		alerts = append(alerts, a.createAlert(result))
+	}
+	a.sendAlerts(alerts)
+}
+
+// SendTestAlert sends a test alert to the AlertManager to verify connectivity
+// File can be a path to a JSON file containing alerts or empty for a default test alert
+func (a *client) SendTestAlert(file string) error {
+	zap.L().Info("Sending test alert to AlertManager",
+		zap.String("host", a.host),
+		zap.String("file", file))
+
+	var alerts []Alert
+
+	// Use provided file or create a default test alert
+	if file != "" {
+		// Try to read the test file
+		data, err := os.ReadFile(file)
+		if err != nil {
+			zap.L().Error("Failed to read test alert file",
+				zap.String("file", file),
+				zap.Error(err))
+			return err
+		}
+
+		if err := json.Unmarshal(data, &alerts); err != nil {
+			zap.L().Error("Failed to parse test alert file",
+				zap.String("file", file),
+				zap.Error(err))
+			return err
+		}
+
+		zap.L().Info("Loaded test alert from file",
+			zap.String("file", file),
+			zap.Int("alertCount", len(alerts)))
+	} else {
+		// Create a default test alert
+		now := time.Now()
+		alerts = []Alert{
+			{
+				Labels: map[string]string{
+					"alertname": "PolicyReporterTest",
+					"severity":  "info",
+					"source":    "policy-reporter",
+				},
+				Annotations: map[string]string{
+					"summary":     "Policy Reporter Test Alert",
+					"description": "This is a test alert sent from Policy Reporter to verify AlertManager connectivity",
+				},
+				StartsAt: now,
+				EndsAt:   now.Add(1 * time.Hour),
+			},
+		}
+		zap.L().Info("Created default test alert")
+	}
+
+	// Send the test alert(s)
+	a.sendAlerts(alerts)
+	return nil
+}
+
+func (a *client) createAlert(result v1alpha2.PolicyReportResult) Alert {
+	labels := map[string]string{
+		"severity": string(result.Severity),
+		"status":   string(result.Result),
+		"source":   result.Source,
+		"policy":   result.Policy,
+		"rule":     result.Rule,
+	}
+
+	annotations := map[string]string{
+		"message": result.Message,
+	}
+
+	// Add resource information if available
+	if result.HasResource() {
+		resource := result.GetResource()
+		resourceString := result.ResourceString()
+
+		// Add resource identifiers to annotations
+		annotations["resource"] = resourceString
+
+		if resource.Kind != "" {
+			annotations["resource_kind"] = resource.Kind
+		}
+
+		if resource.Name != "" {
+			annotations["resource_name"] = resource.Name
+		}
+
+		if resource.Namespace != "" {
+			annotations["resource_namespace"] = resource.Namespace
+		}
+
+		if resource.APIVersion != "" {
+			annotations["resource_apiversion"] = resource.APIVersion
+		}
+	}
+
+	if result.Category != "" {
+		annotations["category"] = result.Category
+	}
+
+	for k, v := range result.Properties {
+		annotations[k] = v
+	}
+
+	for k, v := range a.customFields {
+		annotations[k] = v
+	}
+
+	startsAt := time.Now()
+	return Alert{
+		Labels:      labels,
+		Annotations: annotations,
+		StartsAt:    startsAt,
+		EndsAt:      startsAt.Add(24 * time.Hour),
+	}
+}
+
+func (a *client) sendAlerts(alerts []Alert) {
+	zap.L().Info("Sending alerts to AlertManager",
+		zap.Int("alertCount", len(alerts)),
+		zap.String("endpoint", a.host+"/api/v2/alerts"))
+
+	req, err := targethttp.CreateJSONRequest("POST", a.host+"/api/v2/alerts", alerts)
+	if err != nil {
+		zap.L().Error("Failed to create request", zap.Error(err))
+		return
+	}
+
+	for key, value := range a.headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := a.client.Do(req)
+	targethttp.ProcessHTTPResponse(a.Name(), resp, err)
+}
+
+func (a *client) Type() target.ClientType {
+	return target.BatchSend
+}
+
+// NewClient creates a new AlertManager client to send policy violations
+func NewClient(options Options) Client {
+	return &client{
+		target.NewBaseClient(options.ClientOptions),
+		options.Host,
+		options.Headers,
+		options.CustomFields,
+		options.HTTPClient,
+	}
+}

--- a/pkg/target/alertmanager/alertmanager_test.go
+++ b/pkg/target/alertmanager/alertmanager_test.go
@@ -1,0 +1,478 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/http"
+)
+
+func Test_AlertManagerClient_Send(t *testing.T) {
+	t.Run("Send Single Alert", func(t *testing.T) {
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			assert.Equal(t, "/api/v2/alerts", r.URL.Path)
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "application/json; charset=utf-8", r.Header.Get("Content-Type"))
+
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		})
+
+		result := v1alpha2.PolicyReportResult{
+			Message:  "test message",
+			Policy:   "test-policy",
+			Rule:     "test-rule",
+			Result:   "fail",
+			Source:   "test",
+			Category: "test-category",
+			Severity: "high",
+			Properties: map[string]string{
+				"property1": "value1",
+			},
+		}
+
+		client.Send(result)
+
+		require.Len(t, receivedAlerts, 1)
+		alert := receivedAlerts[0]
+
+		assert.Equal(t, map[string]string{
+			"severity": "high",
+			"status":   "fail",
+			"source":   "test",
+			"policy":   "test-policy",
+			"rule":     "test-rule",
+		}, alert.Labels)
+
+		assert.Equal(t, map[string]string{
+			"message":   "test message",
+			"category":  "test-category",
+			"property1": "value1",
+		}, alert.Annotations)
+
+		assert.True(t, time.Since(alert.StartsAt) < time.Second)
+		assert.True(t, alert.EndsAt.Sub(alert.StartsAt) == 24*time.Hour)
+	})
+
+	t.Run("Send Batch Alerts", func(t *testing.T) {
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			assert.Equal(t, "/api/v2/alerts", r.URL.Path)
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "application/json; charset=utf-8", r.Header.Get("Content-Type"))
+
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		}).(*client)
+
+		results := []v1alpha2.PolicyReportResult{
+			{
+				Message:  "test message 1",
+				Policy:   "test-policy-1",
+				Rule:     "test-rule-1",
+				Result:   "fail",
+				Source:   "test",
+				Severity: "high",
+			},
+			{
+				Message:  "test message 2",
+				Policy:   "test-policy-2",
+				Rule:     "test-rule-2",
+				Result:   "fail",
+				Source:   "test",
+				Severity: "high",
+			},
+		}
+
+		// Create alerts directly instead of using BatchSend
+		alerts := make([]Alert, 0, len(results))
+		for _, result := range results {
+			alerts = append(alerts, client.createAlert(result))
+		}
+		client.sendAlerts(alerts)
+
+		require.Len(t, receivedAlerts, 2)
+		assert.Equal(t, "test-policy-1", receivedAlerts[0].Labels["policy"])
+		assert.Equal(t, "test-policy-2", receivedAlerts[1].Labels["policy"])
+	})
+
+	t.Run("Handle HTTP Error", func(t *testing.T) {
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			w.WriteHeader(stdhttp.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		})
+
+		result := v1alpha2.PolicyReportResult{
+			Message:  "test message",
+			Policy:   "test-policy",
+			Rule:     "test-rule",
+			Result:   "fail",
+			Source:   "test",
+			Severity: "high",
+		}
+
+		// Should not panic
+		client.Send(result)
+	})
+
+	t.Run("With Custom Headers", func(t *testing.T) {
+		receivedHeaders := make(stdhttp.Header)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			receivedHeaders = r.Header
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host: server.URL,
+			Headers: map[string]string{
+				"Authorization": "Bearer test-token",
+				"X-Custom":      "custom-value",
+			},
+			HTTPClient: http.NewClient("", false),
+		})
+
+		result := v1alpha2.PolicyReportResult{
+			Message:  "test message",
+			Policy:   "test-policy",
+			Rule:     "test-rule",
+			Result:   "fail",
+			Source:   "test",
+			Severity: "high",
+		}
+
+		client.Send(result)
+
+		assert.Equal(t, "Bearer test-token", receivedHeaders.Get("Authorization"))
+		assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom"))
+	})
+
+	t.Run("With Custom Fields", func(t *testing.T) {
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host: server.URL,
+			CustomFields: map[string]string{
+				"environment": "production",
+				"team":        "security",
+			},
+			HTTPClient: http.NewClient("", false),
+		})
+
+		result := v1alpha2.PolicyReportResult{
+			Message:  "test message",
+			Policy:   "test-policy",
+			Rule:     "test-rule",
+			Result:   "fail",
+			Source:   "test",
+			Severity: "high",
+		}
+
+		client.Send(result)
+
+		require.Len(t, receivedAlerts, 1)
+		assert.Equal(t, "production", receivedAlerts[0].Annotations["environment"])
+		assert.Equal(t, "security", receivedAlerts[0].Annotations["team"])
+	})
+
+	t.Run("With Resource Information", func(t *testing.T) {
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		})
+
+		result := v1alpha2.PolicyReportResult{
+			Message:  "test message",
+			Policy:   "test-policy",
+			Rule:     "test-rule",
+			Result:   "fail",
+			Source:   "test",
+			Severity: "high",
+			Resources: []corev1.ObjectReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "test-pod",
+					Namespace:  "test-namespace",
+					UID:        "test-uid",
+				},
+			},
+		}
+
+		client.Send(result)
+
+		require.Len(t, receivedAlerts, 1)
+		assert.Equal(t, "test-namespace/pod/test-pod", receivedAlerts[0].Annotations["resource"])
+		assert.Equal(t, "Pod", receivedAlerts[0].Annotations["resource_kind"])
+		assert.Equal(t, "test-pod", receivedAlerts[0].Annotations["resource_name"])
+		assert.Equal(t, "test-namespace", receivedAlerts[0].Annotations["resource_namespace"])
+		assert.Equal(t, "v1", receivedAlerts[0].Annotations["resource_apiversion"])
+	})
+}
+
+func Test_AlertManagerClient_SendTestAlert(t *testing.T) {
+	t.Run("Send Default Test Alert", func(t *testing.T) {
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			assert.Equal(t, "/api/v2/alerts", r.URL.Path)
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "application/json; charset=utf-8", r.Header.Get("Content-Type"))
+
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		}).(*client)
+
+		err := client.SendTestAlert("")
+		require.NoError(t, err)
+
+		require.Len(t, receivedAlerts, 1)
+		alert := receivedAlerts[0]
+
+		assert.Equal(t, "PolicyReporterTest", alert.Labels["alertname"])
+		assert.Equal(t, "info", alert.Labels["severity"])
+		assert.Equal(t, "policy-reporter", alert.Labels["source"])
+		assert.Equal(t, "Policy Reporter Test Alert", alert.Annotations["summary"])
+	})
+
+	t.Run("Send Test Alert From File", func(t *testing.T) {
+		// Create test file
+		testFile := filepath.Join(t.TempDir(), "test-alert.json")
+		testAlert := []Alert{
+			{
+				Labels: map[string]string{
+					"alertname": "TestAlert",
+					"severity":  "warning",
+					"source":    "policy-reporter-test",
+				},
+				Annotations: map[string]string{
+					"summary":     "Test Alert From File",
+					"description": "This is a test alert loaded from a file",
+				},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		}
+
+		alertJSON, err := json.Marshal(testAlert)
+		require.NoError(t, err)
+
+		err = os.WriteFile(testFile, alertJSON, 0644)
+		require.NoError(t, err)
+
+		// Test with the file
+		receivedAlerts := make([]Alert, 0)
+		server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			var alerts []Alert
+			err := json.NewDecoder(r.Body).Decode(&alerts)
+			require.NoError(t, err)
+			receivedAlerts = alerts
+			w.WriteHeader(stdhttp.StatusOK)
+		}))
+		defer server.Close()
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       server.URL,
+			HTTPClient: http.NewClient("", false),
+		}).(*client)
+
+		err = client.SendTestAlert(testFile)
+		require.NoError(t, err)
+
+		require.Len(t, receivedAlerts, 1)
+		assert.Equal(t, "TestAlert", receivedAlerts[0].Labels["alertname"])
+		assert.Equal(t, "warning", receivedAlerts[0].Labels["severity"])
+		assert.Equal(t, "policy-reporter-test", receivedAlerts[0].Labels["source"])
+		assert.Equal(t, "Test Alert From File", receivedAlerts[0].Annotations["summary"])
+	})
+
+	t.Run("Handle Invalid File Path", func(t *testing.T) {
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       "http://example.com",
+			HTTPClient: http.NewClient("", false),
+		}).(*client)
+
+		err := client.SendTestAlert("/non/existent/file.json")
+		require.Error(t, err)
+	})
+
+	t.Run("Handle Invalid JSON in File", func(t *testing.T) {
+		// Create invalid JSON file
+		testFile := filepath.Join(t.TempDir(), "invalid.json")
+		err := os.WriteFile(testFile, []byte("{invalid-json"), 0644)
+		require.NoError(t, err)
+
+		client := NewClient(Options{
+			ClientOptions: target.ClientOptions{
+				Name: "test",
+			},
+			Host:       "http://example.com",
+			HTTPClient: http.NewClient("", false),
+		}).(*client)
+
+		err = client.SendTestAlert(testFile)
+		require.Error(t, err)
+	})
+}
+
+func Test_AlertManagerClient_Type(t *testing.T) {
+	client := NewClient(Options{
+		ClientOptions: target.ClientOptions{
+			Name: "test",
+		},
+		HTTPClient: http.NewClient("", false),
+	})
+
+	assert.Equal(t, target.BatchSend, client.Type())
+}
+
+// mockReportInterface is a simple implementation of ReportInterface for testing
+type mockReportInterface struct {
+	name      string
+	namespace string
+	scope     *corev1.ObjectReference
+	results   []v1alpha2.PolicyReportResult
+}
+
+func (m *mockReportInterface) GetName() string {
+	return m.name
+}
+
+func (m *mockReportInterface) GetNamespace() string {
+	return m.namespace
+}
+
+func (m *mockReportInterface) GetResults() []v1alpha2.PolicyReportResult {
+	return m.results
+}
+
+func (m *mockReportInterface) GetScope() *corev1.ObjectReference {
+	return m.scope
+}
+
+func (m *mockReportInterface) SetResults(results []v1alpha2.PolicyReportResult) {
+	m.results = results
+}
+
+func (m *mockReportInterface) GetSummary() v1alpha2.PolicyReportSummary {
+	return v1alpha2.PolicyReportSummary{}
+}
+
+func (m *mockReportInterface) GetSource() string {
+	if len(m.results) == 0 {
+		return ""
+	}
+	return m.results[0].Source
+}
+
+func (m *mockReportInterface) GetKinds() []string {
+	return []string{}
+}
+
+func (m *mockReportInterface) GetSeverities() []string {
+	return []string{}
+}
+
+func (m *mockReportInterface) HasResult(string) bool {
+	return false
+}
+
+func (m *mockReportInterface) GetAnnotations() map[string]string {
+	return map[string]string{}
+}
+
+func (m *mockReportInterface) GetCreationTimestamp() metav1.Time {
+	return metav1.Now()
+}

--- a/pkg/target/alertmanager/client.go
+++ b/pkg/target/alertmanager/client.go
@@ -1,0 +1,13 @@
+package alertmanager
+
+import (
+	"github.com/kyverno/policy-reporter/pkg/target"
+)
+
+// Client extends the target.Client interface with AlertManager-specific functionality
+type Client interface {
+	target.Client
+}
+
+// Ensure the client type implements the Client interface
+var _ Client = (*client)(nil)

--- a/pkg/target/collection.go
+++ b/pkg/target/collection.go
@@ -26,6 +26,7 @@ const (
 	Kinesis       TargetType = "Kinesis"
 	SecurityHub   TargetType = "SecurityHub"
 	GCS           TargetType = "GCS"
+	AlertManager  TargetType = "AlertManager"
 )
 
 type Targets struct {
@@ -42,6 +43,7 @@ type Targets struct {
 	Kinesis       *v1alpha1.Config[v1alpha1.KinesisOptions]       `mapstructure:"kinesis"`
 	SecurityHub   *v1alpha1.Config[v1alpha1.SecurityHubOptions]   `mapstructure:"securityHub"`
 	GCS           *v1alpha1.Config[v1alpha1.GCSOptions]           `mapstructure:"gcs"`
+	AlertManager  *v1alpha1.Config[v1alpha1.AlertManagerOptions]  `mapstructure:"alertManager"`
 }
 
 type TargetConfig interface {

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/target/teams"
 	"github.com/kyverno/policy-reporter/pkg/target/telegram"
 	"github.com/kyverno/policy-reporter/pkg/target/webhook"
+	"github.com/kyverno/policy-reporter/pkg/target/alertmanager"
 	"github.com/kyverno/policy-reporter/pkg/validate"
 )
 
@@ -97,6 +98,7 @@ func (f *TargetFactory) CreateClients(config *target.Targets) *target.Collection
 	targets = append(targets, createClients("Kinesis", config.Kinesis, f.CreateKinesisTarget)...)
 	targets = append(targets, createClients("SecurityHub", config.SecurityHub, f.CreateSecurityHubTarget)...)
 	targets = append(targets, createClients("GoogleCloudStorage", config.GCS, f.CreateGCSTarget)...)
+	targets = append(targets, createClients("AlertManager", config.AlertManager, f.CreateAlertManagerTarget)...)
 
 	return target.NewCollection(targets...)
 }
@@ -823,6 +825,51 @@ func (f *TargetFactory) CreateGCSTarget(config, parent *v1alpha1.Config[v1alpha1
 			Client:       gcsClient,
 			CustomFields: config.CustomFields,
 			Prefix:       config.Config.Prefix,
+		}),
+	}
+}
+
+func (f *TargetFactory) CreateAlertManagerTarget(config, parent *v1alpha1.Config[v1alpha1.AlertManagerOptions]) *target.Target {
+	if config == nil || config.Config == nil {
+		return nil
+	}
+
+	if (parent.SecretRef != "" && f.secretClient != nil) || parent.MountedSecret != "" {
+		f.mapSecretValues(parent, parent.SecretRef, parent.MountedSecret)
+	}
+
+	if (config.SecretRef != "" && f.secretClient != nil) || config.MountedSecret != "" {
+		f.mapSecretValues(config, config.SecretRef, config.MountedSecret)
+	}
+
+	if config.Config.Host == "" && parent.Config.Host == "" {
+		return nil
+	}
+
+	setFallback(&config.Config.Host, parent.Config.Host)
+	setFallback(&config.Config.Certificate, parent.Config.Certificate)
+	setBool(&config.Config.SkipTLS, parent.Config.SkipTLS)
+
+	config.MapBaseParent(parent)
+
+	zap.S().Infof("%s configured", config.Name)
+
+	return &target.Target{
+		ID:           uuid.NewString(),
+		Type:         target.AlertManager,
+		Config:       config,
+		ParentConfig: parent,
+		Client: alertmanager.NewClient(alertmanager.Options{
+			ClientOptions: target.ClientOptions{
+				Name:                  config.Name,
+				SkipExistingOnStartup: config.SkipExisting,
+				ResultFilter:          f.createResultFilter(config.Filter, config.MinimumSeverity, config.Sources),
+				ReportFilter:          createReportFilter(config.Filter),
+			},
+			Host:         config.Config.Host,
+			Headers:      config.Config.Headers,
+			CustomFields: config.CustomFields,
+			HTTPClient:   http.NewClient(config.Config.Certificate, config.Config.SkipTLS),
 		}),
 	}
 }

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/secrets"
 	"github.com/kyverno/policy-reporter/pkg/report"
 	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/alertmanager"
 	"github.com/kyverno/policy-reporter/pkg/target/discord"
 	"github.com/kyverno/policy-reporter/pkg/target/elasticsearch"
 	"github.com/kyverno/policy-reporter/pkg/target/gcs"
@@ -34,7 +35,6 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/target/teams"
 	"github.com/kyverno/policy-reporter/pkg/target/telegram"
 	"github.com/kyverno/policy-reporter/pkg/target/webhook"
-	"github.com/kyverno/policy-reporter/pkg/target/alertmanager"
 	"github.com/kyverno/policy-reporter/pkg/validate"
 )
 
@@ -1003,6 +1003,17 @@ func (f *TargetFactory) mapSecretValues(config any, ref, mountedSecret string) {
 		}
 		if values.Host != "" {
 			c.Config.Webhook = values.Host
+		}
+
+	case *v1alpha1.Config[v1alpha1.AlertManagerOptions]:
+		if values.Host != "" {
+			c.Config.Host = values.Host
+		}
+		if values.Token != "" {
+			if c.Config.Headers == nil {
+				c.Config.Headers = make(map[string]string)
+			}
+			c.Config.Headers["Authorization"] = values.Token
 		}
 	}
 }

--- a/test/alertmanager/README.md
+++ b/test/alertmanager/README.md
@@ -1,0 +1,33 @@
+# AlertManager Target Test
+
+This is a simple test program to verify the AlertManager target integration.
+
+## Prerequisites
+
+- Running AlertManager instance (default: http://localhost:9093)
+- Go environment
+
+## How to run
+
+```bash
+# From the project root
+cd test/alertmanager
+go run main.go
+```
+
+## Expected results
+
+1. The test sends two types of alerts to the AlertManager:
+   - A single test alert with policy "test-policy"
+   - Two batch alerts with policies "batch-policy-1" and "batch-policy-2"
+
+2. Check the AlertManager UI to verify the alerts are received with:
+   - Correct labels (severity, status, source, policy, rule)
+   - Correct annotations (message, category, custom properties)
+   - Custom fields (environment: test, test: true)
+
+## Troubleshooting
+
+- If AlertManager is running on a different URL, edit `alertManagerURL` in main.go
+- Ensure the AlertManager API endpoint is accessible
+- Check AlertManager logs for any errors 

--- a/test/alertmanager/main.go
+++ b/test/alertmanager/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/target"
+	"github.com/kyverno/policy-reporter/pkg/target/alertmanager"
+	"github.com/kyverno/policy-reporter/pkg/target/http"
+)
+
+func main() {
+	// Create a test result
+	result := v1alpha2.PolicyReportResult{
+		Message:  "Test policy violation from manual test",
+		Policy:   "test-policy",
+		Rule:     "test-rule",
+		Result:   "fail",
+		Source:   "policy-reporter",
+		Category: "test-category",
+		Severity: "warning",
+		Properties: map[string]string{
+			"test_property": "test_value",
+		},
+	}
+
+	// Create the AlertManager client
+	// Replace with your AlertManager URL
+	alertManagerURL := "http://localhost:9093"
+
+	client := alertmanager.NewClient(alertmanager.Options{
+		ClientOptions: target.ClientOptions{
+			Name: "test-client",
+		},
+		Host: alertManagerURL,
+		Headers: map[string]string{
+			"X-Test-Header": "test-value",
+		},
+		CustomFields: map[string]string{
+			"environment": "test",
+			"test":        "true",
+		},
+		HTTPClient: http.NewClient("", false),
+	})
+
+	// Send the test alert
+	fmt.Println("Sending test alert to", alertManagerURL)
+	client.Send(result)
+
+	// Also test batch send
+	results := []v1alpha2.PolicyReportResult{
+		{
+			Message:  "Batch test alert 1",
+			Policy:   "batch-policy-1",
+			Rule:     "batch-rule-1",
+			Result:   "fail",
+			Source:   "policy-reporter",
+			Severity: "warning",
+		},
+		{
+			Message:  "Batch test alert 2",
+			Policy:   "batch-policy-2",
+			Rule:     "batch-rule-2",
+			Result:   "fail",
+			Source:   "policy-reporter",
+			Severity: "warning",
+		},
+	}
+
+	fmt.Println("Sending batch test alerts")
+	client.BatchSend(nil, results)
+
+	// Wait a moment to ensure alerts are sent before the program exits
+	time.Sleep(500 * time.Millisecond)
+
+	fmt.Println("Test completed. Check AlertManager UI to verify alerts were received.")
+}


### PR DESCRIPTION
# Add AlertManager Target Implementation

## Description
This PR adds support for sending policy violations directly to AlertManager as alerts, enhancing the monitoring capabilities of Policy Reporter. AlertManager integration allows users to leverage their existing alerting infrastructure for policy violation notifications.

## Features
- Send policy violations as alerts to AlertManager API (v2)
- Support for both single alerts and batch sends
- Configuration via TargetConfig CRD
- Custom headers including authentication support
- TLS configuration (certificates and skip verification options)
- Custom fields can be added to alert annotations
- Rich metadata in alerts including severity, status, source, policy, and rule information

## Implementation Details
- Added new `AlertManagerOptions` type to TargetConfig API
- Implemented AlertManager client with send and batch send capabilities
- Added comprehensive test suite with 84.2% code coverage
- Integrated with existing target collection framework
- Added view mapping for UI integration
- Created manual test tools for verification

## How to Use
Create a TargetConfig like:
```yaml
apiVersion: v1alpha1
kind: TargetConfig
metadata:
  name: alertmanager
spec:
  alertManager:
    host: http://alertmanager.monitoring:9093
    skipTLS: true
    minimumSeverity: warning
    sources:
      - kyverno
      - policy-reporter
```

## Testing
- Unit tests with 84.2% code coverage
- Manual test application in `test/alertmanager/main.go`
- Curl script for direct API testing in `test/alertmanager/test-curl.sh`
- Test alerts verified with a local AlertManager instance

![image](https://github.com/user-attachments/assets/881c2f43-16f4-4b9e-8d50-71b62023f56d)


This PR addresses feature request #XXX (Please replace with actual issue number if applicable)

##Fixes #895
