### PR TITLE
chore(staticcheck) Fix all remaining issues reported

### DIFF
--- a/pkg/api/v1/api.go
+++ b/pkg/api/v1/api.go
@@ -58,7 +58,7 @@ func (h *APIHandler) ListTargets(ctx *gin.Context) {
 func (h *APIHandler) ListPolicyReports(ctx *gin.Context) {
 	filter := api.BuildFilter(ctx)
 
-	count, err := h.store.CountPolicyReports(ctx, filter)
+	count, _ := h.store.CountPolicyReports(ctx, filter)
 	list, err := h.store.FetchPolicyReports(ctx, filter, api.BuildPagination(ctx, []string{"namespace", "name"}))
 
 	api.SendResponse(ctx, api.Paginated[PolicyReport]{Count: count, Items: MapPolicyReports(list)}, "failed to load policy reports", err)
@@ -67,7 +67,7 @@ func (h *APIHandler) ListPolicyReports(ctx *gin.Context) {
 func (h *APIHandler) ListClusterPolicyReports(ctx *gin.Context) {
 	filter := api.BuildFilter(ctx)
 
-	count, err := h.store.CountClusterPolicyReports(ctx, filter)
+	count, _ := h.store.CountClusterPolicyReports(ctx, filter)
 	list, err := h.store.FetchClusterPolicyReports(ctx, filter, api.BuildPagination(ctx, []string{"name"}))
 
 	api.SendResponse(ctx, api.Paginated[PolicyReport]{Count: count, Items: MapPolicyReports(list)}, "failed to load policy reports", err)
@@ -130,7 +130,7 @@ func (h *APIHandler) ListNamespacedStatusCounts(ctx *gin.Context) {
 func (h *APIHandler) ListClusterResults(ctx *gin.Context) {
 	filter := api.BuildFilter(ctx)
 
-	count, err := h.store.CountResults(ctx, false, filter)
+	count, _ := h.store.CountResults(ctx, false, filter)
 	list, err := h.store.FetchResults(ctx, false, filter, api.BuildPagination(ctx, defaultOrder))
 
 	api.SendResponse(ctx, api.Paginated[Result]{Count: count, Items: MapResults(list)}, "failed to load results", err)
@@ -139,7 +139,7 @@ func (h *APIHandler) ListClusterResults(ctx *gin.Context) {
 func (h *APIHandler) ListNamespacedResults(ctx *gin.Context) {
 	filter := api.BuildFilter(ctx)
 
-	count, err := h.store.CountResults(ctx, true, filter)
+	count, _ := h.store.CountResults(ctx, true, filter)
 	list, err := h.store.FetchResults(ctx, true, filter, api.BuildPagination(ctx, defaultOrder))
 
 	api.SendResponse(ctx, api.Paginated[Result]{Count: count, Items: MapResults(list)}, "failed to load results", err)

--- a/pkg/report/publisher.go
+++ b/pkg/report/publisher.go
@@ -42,9 +42,7 @@ func (p *lifecycleEventPublisher) RegisterPostListener(name string, listener Pol
 }
 
 func (p *lifecycleEventPublisher) UnregisterPostListener(name string) {
-	if _, ok := p.postListeners[name]; ok {
-		delete(p.postListeners, name)
-	}
+	delete(p.postListeners, name)
 }
 
 func (p *lifecycleEventPublisher) GetListener() map[string]PolicyReportListener {

--- a/pkg/report/source_filter.go
+++ b/pkg/report/source_filter.go
@@ -150,5 +150,5 @@ func Uncontrolled(owner []metav1.OwnerReference) bool {
 }
 
 func Match(polr v1alpha2.ReportInterface, selector ReportSelector) bool {
-	return selector.Source == "" || strings.ToLower(selector.Source) == strings.ToLower(polr.GetSource())
+	return selector.Source == "" || strings.EqualFold(selector.Source, polr.GetSource())
 }


### PR DESCRIPTION
Hi,

This trivial PR fixes all remaining staticcheck issues.

```bash
golangci-lint run --enable-only staticcheck ./...
pkg/api/v1/api.go:61:2: SA4006: this value of err is never used (staticcheck)
        count, err := h.store.CountPolicyReports(ctx, filter)
        ^
 103 ↲
pkg/api/v1/api.go:70:2: SA4006: this value of err is never used (staticcheck)
        count, err := h.store.CountClusterPolicyReports(ctx, filter)
        ^
pkg/api/v1/api.go:133:2: SA4006: this value of err is never used (staticcheck)
        count, err := h.store.CountResults(ctx, false, filter)
        ^
pkg/report/publisher.go:45:2: S1033: unnecessary guard around call to delete (staticcheck)
        if _, ok := p.postListeners[name]; ok {
        ^
pkg/report/source_filter.go:153:34: SA6005: should use strings.EqualFold instead (staticcheck)
        return selector.Source == "" || strings.ToLower(selector.Source) == strings.ToLower(polr.GetSource())
   1 package report↲
                                        ^
5 issues:
* staticcheck: 5
```

Thank you!