### PR TITLE
feat: Add keepalive functionality for webhook target.

### DIFF
--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -203,6 +203,14 @@ config:
   webhook: {{ .webhook | quote }}
   certificate: {{ .certificate | quote }}
   skipTLS: {{ .skipTLS }}
+  {{- if .keepalive }}
+  keepalive:
+    interval: {{ .keepalive.interval | quote }}
+    {{- if .keepalive.params }}
+    params:
+      {{- toYaml .keepalive.params | nindent 6 }}
+    {{- end }}
+  {{- end }}
   {{- with .headers }}
   headers:
   {{- toYaml . | nindent 4 }}

--- a/charts/policy-reporter/templates/policyreporter.kyverno.io_targetconfigs.yaml
+++ b/charts/policy-reporter/templates/policyreporter.kyverno.io_targetconfigs.yaml
@@ -379,6 +379,16 @@ spec:
                     type: boolean
                   webhook:
                     type: string
+                  keepalive:
+                    type: object
+                    properties:
+                      interval:
+                        type: string
+                        pattern: '^\d+(s|m|h)$'
+                      params:
+                        type: object
+                        additionalProperties:
+                          type: string
                 required:
                 - certificate
                 - headers

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -536,6 +536,12 @@ target:
     skipExistingOnStartup: true
     # -- Added as additional labels
     customFields: {}
+    # -- Keepalive configuration
+    keepalive:
+      # -- Duration string like "30s" for heartbeat interval, '0' - disabled
+      interval: "0"
+      # -- Additional parameters to include in heartbeat payload
+      params: {}
     # -- Filter Results which should send to this target
     # Wildcars for namespaces and policies are supported, you can either define exclude or include values
     # Filters are available for all targets except the UI

--- a/pkg/crd/api/targetconfig/v1alpha1/configs.go
+++ b/pkg/crd/api/targetconfig/v1alpha1/configs.go
@@ -11,6 +11,13 @@ type AWSConfig struct {
 	Endpoint string `mapstructure:"endpoint" json:"endpoint"`
 }
 
+type KeepaliveConfig struct {
+	// +optional
+	Interval string `mapstructure:"interval" json:"interval"` // Duration string like "5m"
+	// +optional
+	Params map[string]string `mapstructure:"params" json:"params"`
+}
+
 type WebhookOptions struct {
 	Webhook string `mapstructure:"webhook" json:"webhook"`
 	// +optional
@@ -19,6 +26,8 @@ type WebhookOptions struct {
 	Certificate string `mapstructure:"certificate" json:"certificate"`
 	// +optional
 	Headers map[string]string `mapstructure:"headers" json:"headers"`
+	// +optional
+	Keepalive *KeepaliveConfig `mapstructure:"keepalive" json:"keepalive"`
 }
 
 type JiraOptions struct {

--- a/pkg/listener/send_result_test.go
+++ b/pkg/listener/send_result_test.go
@@ -49,6 +49,8 @@ func (c *client) Reset(_ context.Context) error {
 	return nil
 }
 
+func (c *client) SendHeartbeat() {}
+
 func (c *client) CleanUp(_ context.Context, _ v1alpha2.ReportInterface) {
 	c.cleanupCalled = true
 }

--- a/pkg/target/client.go
+++ b/pkg/target/client.go
@@ -43,6 +43,8 @@ type Client interface {
 	CleanUp(context.Context, v1alpha2.ReportInterface)
 	// Reset the current state in the related target
 	Reset(context.Context) error
+	// SendHeartbeat sends a periodic keepalive message
+	SendHeartbeat()
 }
 
 type ResultFilterFactory struct {
@@ -245,6 +247,8 @@ func (c *BaseClient) Reset(_ context.Context) error {
 func (c *BaseClient) CleanUp(_ context.Context, _ v1alpha2.ReportInterface) {}
 
 func (c *BaseClient) BatchSend(_ v1alpha2.ReportInterface, _ []v1alpha2.PolicyReportResult) {}
+
+func (c *BaseClient) SendHeartbeat() {} // Default no-op implementation
 
 func NewBaseClient(options ClientOptions) BaseClient {
 	return BaseClient{options.Name, options.SkipExistingOnStartup, options.ResultFilter, options.ReportFilter}

--- a/pkg/target/collection.go
+++ b/pkg/target/collection.go
@@ -3,6 +3,7 @@ package target
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -50,12 +51,13 @@ type TargetConfig interface {
 }
 
 type Target struct {
-	ID           string
-	Type         TargetType
-	Client       Client
-	ParentConfig TargetConfig
-	Config       TargetConfig
-	Keepalive    time.Duration
+	ID               string
+	Type             TargetType
+	Client           Client
+	ParentConfig     TargetConfig
+	Config           TargetConfig
+	Keepalive        time.Duration
+	keepaliveRunning uint32 // Simple atomic flag
 }
 
 func (t *Target) Secret() string {
@@ -66,23 +68,30 @@ func (t *Target) Secret() string {
 	return t.ParentConfig.Secret()
 }
 
-func (t *Target) startKeepalive() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ticker := time.NewTicker(t.Keepalive)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if sendClient, ok := t.Client.(interface{ SendHeartbeat() }); ok {
-				sendClient.SendHeartbeat()
-			}
-		case <-ctx.Done():
-			return
-		}
+func (t *Target) StartKeepalive() {
+	// Simple atomic check to prevent duplicates
+	if !atomic.CompareAndSwapUint32(&t.keepaliveRunning, 0, 1) {
+		zap.L().Info("keepalive already started for target: ", zap.String("target", t.Type))
+		return
 	}
+	zap.L().Info("starting keepalive for target: ", zap.String("target", t.Type))
+	go func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		defer atomic.StoreUint32(&t.keepaliveRunning, 0)
+
+		ticker := time.NewTicker(t.Keepalive)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				t.Client.SendHeartbeat()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 type Collection struct {
@@ -186,12 +195,6 @@ func NewCollection(targets ...*Target) *Collection {
 
 	for _, t := range targets {
 		if t != nil {
-			if t.Keepalive > 0 {
-				zap.L().Info("starting keepalive for target",
-					zap.String("type", t.Type),
-					zap.String("name", t.Client.Name()))
-				go t.startKeepalive()
-			}
 			collection.Update(t)
 		}
 	}

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -98,34 +98,52 @@ func (f *TargetFactory) CreateClients(config *target.Targets) *target.Collection
 	targets = append(targets, createClients("SecurityHub", config.SecurityHub, f.CreateSecurityHubTarget)...)
 	targets = append(targets, createClients("GoogleCloudStorage", config.GCS, f.CreateGCSTarget)...)
 
-	return target.NewCollection(targets...)
+	collection := target.NewCollection(targets...)
+
+	for _, t := range targets {
+		if t != nil && t.Keepalive > 0 {
+			go t.StartKeepalive()
+		}
+	}
+
+	return collection
 }
 
 func (f *TargetFactory) CreateSingleClient(tc *v1alpha1.TargetConfig) (*target.Target, error) {
-	if tc.Spec.S3 != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.S3), f.CreateS3Target)), nil
-	} else if tc.Spec.Webhook != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Webhook), f.CreateWebhookTarget)), nil
-	} else if tc.Spec.GCS != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.GCS), f.CreateGCSTarget)), nil
-	} else if tc.Spec.ElasticSearch != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.ElasticSearch), f.CreateElasticsearchTarget)), nil
-	} else if tc.Spec.Telegram != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Telegram), f.CreateTelegramTarget)), nil
-	} else if tc.Spec.Kinesis != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Kinesis), f.CreateKinesisTarget)), nil
-	} else if tc.Spec.SecurityHub != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.SecurityHub), f.CreateSecurityHubTarget)), nil
-	} else if tc.Spec.Loki != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Loki), f.CreateLokiTarget)), nil
-	} else if tc.Spec.Slack != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Slack), f.CreateSlackTarget)), nil
-	} else if tc.Spec.Teams != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Teams), f.CreateTeamsTarget)), nil
-	} else if tc.Spec.Jira != nil {
-		return helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Jira), f.CreateJiraTarget)), nil
+	var target *target.Target
+
+	switch {
+	case tc.Spec.S3 != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.S3), f.CreateS3Target))
+	case tc.Spec.Webhook != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Webhook), f.CreateWebhookTarget))
+	case tc.Spec.GCS != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.GCS), f.CreateGCSTarget))
+	case tc.Spec.ElasticSearch != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.ElasticSearch), f.CreateElasticsearchTarget))
+	case tc.Spec.Telegram != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Telegram), f.CreateTelegramTarget))
+	case tc.Spec.Kinesis != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Kinesis), f.CreateKinesisTarget))
+	case tc.Spec.SecurityHub != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.SecurityHub), f.CreateSecurityHubTarget))
+	case tc.Spec.Loki != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Loki), f.CreateLokiTarget))
+	case tc.Spec.Slack != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Slack), f.CreateSlackTarget))
+	case tc.Spec.Teams != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Teams), f.CreateTeamsTarget))
+	case tc.Spec.Jira != nil:
+		target = helper.First(createClients(tc.Name, createConfig(tc, tc.Spec.Jira), f.CreateJiraTarget))
+	default:
+		return nil, fmt.Errorf("invalid target type passed")
 	}
-	return nil, fmt.Errorf("invalid target type passed")
+
+	if target != nil && target.Keepalive > 0 {
+		go target.StartKeepalive()
+	}
+
+	return target, nil
 }
 
 func (f *TargetFactory) CreateSlackTarget(config, parent *v1alpha1.Config[v1alpha1.SlackOptions]) *target.Target {

--- a/pkg/target/webhook/webhook.go
+++ b/pkg/target/webhook/webhook.go
@@ -1,7 +1,12 @@
 package webhook
 
 import (
+	"time"
+
+	"go.uber.org/zap"
+
 	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
+	"github.com/kyverno/policy-reporter/pkg/crd/api/targetconfig/v1alpha1"
 	"github.com/kyverno/policy-reporter/pkg/target"
 	"github.com/kyverno/policy-reporter/pkg/target/http"
 )
@@ -13,6 +18,7 @@ type Options struct {
 	Headers      map[string]string
 	CustomFields map[string]string
 	HTTPClient   http.Client
+	Keepalive    *v1alpha1.KeepaliveConfig
 }
 
 type client struct {
@@ -21,6 +27,7 @@ type client struct {
 	headers      map[string]string
 	customFields map[string]string
 	client       http.Client
+	keepalive    *v1alpha1.KeepaliveConfig
 }
 
 func (e *client) Send(result v1alpha2.PolicyReportResult) {
@@ -51,17 +58,50 @@ func (e *client) Send(result v1alpha2.PolicyReportResult) {
 	http.ProcessHTTPResponse(e.Name(), resp, err)
 }
 
+func (e *client) SendHeartbeat() {
+	payload := map[string]interface{}{
+		"event": "heartbeat",
+		"time":  time.Now().Format(time.RFC3339),
+	}
+
+	// Add keepalive params if configured
+	if e.keepalive != nil {
+		if len(e.keepalive.Params) > 0 {
+			for k, v := range e.keepalive.Params {
+				payload[k] = v
+			}
+		}
+	}
+
+	zap.L().Debug("sending heartbeat payload",
+		zap.String("target", e.Name()),
+		zap.Any("payload", payload))
+
+	req, err := http.CreateJSONRequest("POST", e.host, payload)
+	if err != nil {
+		return
+	}
+
+	for header, value := range e.headers {
+		req.Header.Set(header, value)
+	}
+
+	resp, err := e.client.Do(req)
+	http.ProcessHTTPResponse(e.Name()+"-heartbeat", resp, err)
+}
+
 func (e *client) Type() target.ClientType {
 	return target.SingleSend
 }
 
-// NewClient creates a new loki.client to send Results to Elasticsearch
+// NewClient creates a new webhook client
 func NewClient(options Options) target.Client {
 	return &client{
-		target.NewBaseClient(options.ClientOptions),
-		options.Host,
-		options.Headers,
-		options.CustomFields,
-		options.HTTPClient,
+		BaseClient:   target.NewBaseClient(options.ClientOptions),
+		host:         options.Host,
+		headers:      options.Headers,
+		customFields: options.CustomFields,
+		client:       options.HTTPClient,
+		keepalive:    options.Keepalive,
 	}
 }


### PR DESCRIPTION
Hi,
Our system relies on reports sent from multiple external clusters (owned by other teams or clients), but we currently have no visibility into their runtime logs or metrics. To ensure reliable report delivery especially when Kyverno is unavailable or failing. Fortunately, it's not difficult to implement a keepalive mechanism for the webhook target which is in this PR.

it helps to:
- Proactively detect connectivity issues. We can monitor presence of keepalive messages.
- Maintain reliability without requiring access to external clusters.

I’d appreciate your feedback on the implementation! Let me know if you’d like adjustments.