### PR TITLE
charts: allow setting arbitrary configuration settings via 'extraConfig' option

### DIFF
--- a/charts/policy-reporter/configs/core.tmpl
+++ b/charts/policy-reporter/configs/core.tmpl
@@ -187,3 +187,7 @@ database:
   dsn: {{ .Values.database.dsn }}
   secretRef: {{ .Values.database.secretRef }}
   mountedSecret: {{ .Values.database.mountedSecret }}
+
+{{- with .Values.extraConfig }}
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/policy-reporter/configs/kyverno-plugin.tmpl
+++ b/charts/policy-reporter/configs/kyverno-plugin.tmpl
@@ -25,3 +25,7 @@ core:
 blockReports:
   {{- toYaml . | nindent 4 }}
 {{- end }}
+
+{{- with .Values.plugin.kyverno.extraConfig }}
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/policy-reporter/configs/trivy-plugin.tmpl
+++ b/charts/policy-reporter/configs/trivy-plugin.tmpl
@@ -27,3 +27,7 @@ trivy:
 github:
   token: {{ .Values.plugin.trivy.github.token | quote }}
   disable: {{ .Values.plugin.trivy.github.disable }}
+
+{{- with .Values.plugin.trivy.extraConfig }}
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/policy-reporter/configs/ui.tmpl
+++ b/charts/policy-reporter/configs/ui.tmpl
@@ -92,3 +92,7 @@ openIDConnect:
 oauth:
   {{- toYaml . | nindent 4 }}
 {{- end }}
+
+{{- with .Values.plugin.ui.extraConfig }}
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1216,6 +1216,9 @@ ui:
     # -- Deployment values
     volumes: []
 
+  # -- Extra configuration options appended to UI settings
+  extraConfig: {}
+
 plugin:
   kyverno:
     # -- (bool) Enable Kyverno Plugin
@@ -1426,6 +1429,9 @@ plugin:
 
       # -- Deployment values
       volumes: []
+
+    # -- Extra configuration options appended to kyverno plugin settings
+    extraConfig: {}
 
   trivy:
     # -- (bool) Enable Trivy Operator Plugin
@@ -1662,6 +1668,9 @@ plugin:
       # -- Deployment values
       volumes: []
 
+    # -- Extra configuration options appended to trivy plugin settings
+    extraConfig: {}
+
 monitoring:
   # -- Enables the Prometheus Operator integration
   enabled: false
@@ -1794,3 +1803,6 @@ monitoring:
 
 # -- list of extra manifests
 extraManifests: []
+
+# -- Extra configuration options appended to core policy reporter
+extraConfig: {}


### PR DESCRIPTION
Applies to the core policy reporter, UI, trivy and kyverno plugin.

As not all settings are exposed via templated settings and not all options require exposure, an additional 'extraConfig' object type value is added which allows adding arbitrary configuration.