### PR TITLE
Add periodic shipping of policyreports to policy_report_client

### DIFF
--- a/charts/policy-reporter/configs/core.tmpl
+++ b/charts/policy-reporter/configs/core.tmpl
@@ -187,3 +187,8 @@ database:
   dsn: {{ .Values.database.dsn }}
   secretRef: {{ .Values.database.secretRef }}
   mountedSecret: {{ .Values.database.mountedSecret }}
+
+{{- with .Values.periodicSync }}
+periodicSync:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -824,6 +824,11 @@ database:
   # supported fields: username, password, host, dsn, database
   mountedSecret: ""
 
+# Add this configuration section for periodic sync
+periodicSync:
+  enabled: false
+  interval: 30 # minutes
+
 # enabled if replicaCount > 1
 podDisruptionBudget:
   # -- Configures the minimum available pods for policy-reporter disruptions.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -180,25 +180,31 @@ type CRD struct {
 }
 
 // Config of the PolicyReporter
+type PeriodicSyncConfig struct {
+	Enabled  bool `mapstructure:"enabled"`
+	Interval int  `mapstructure:"interval"` // in minutes
+}
+
 type Config struct {
 	Version        string
-	Namespace      string         `mapstructure:"namespace"`
-	API            API            `mapstructure:"api"`
-	WorkerCount    int            `mapstructure:"worker"`
-	DBFile         string         `mapstructure:"dbfile"`
-	Metrics        Metrics        `mapstructure:"metrics"`
-	REST           REST           `mapstructure:"rest"`
-	ReportFilter   ReportFilter   `mapstructure:"reportFilter"`
-	SourceFilters  []SourceFilter `mapstructure:"sourceFilters"`
-	Redis          Redis          `mapstructure:"redis"`
-	Profiling      Profiling      `mapstructure:"profiling"`
-	EmailReports   EmailReports   `mapstructure:"emailReports"`
-	LeaderElection LeaderElection `mapstructure:"leaderElection"`
-	K8sClient      K8sClient      `mapstructure:"k8sClient"`
-	Logging        Logging        `mapstructure:"logging"`
-	Database       Database       `mapstructure:"database"`
-	Targets        target.Targets `mapstructure:"target"`
-	SourceConfig   []SourceConfig `mapstructure:"sourceConfig"`
-	Templates      Templates      `mapstructure:"templates"`
-	CRD            CRD            `mapstructure:"crd"`
+	Namespace      string             `mapstructure:"namespace"`
+	API            API                `mapstructure:"api"`
+	WorkerCount    int                `mapstructure:"worker"`
+	DBFile         string             `mapstructure:"dbfile"`
+	Metrics        Metrics            `mapstructure:"metrics"`
+	REST           REST               `mapstructure:"rest"`
+	ReportFilter   ReportFilter       `mapstructure:"reportFilter"`
+	SourceFilters  []SourceFilter     `mapstructure:"sourceFilters"`
+	Redis          Redis              `mapstructure:"redis"`
+	Profiling      Profiling          `mapstructure:"profiling"`
+	EmailReports   EmailReports       `mapstructure:"emailReports"`
+	LeaderElection LeaderElection     `mapstructure:"leaderElection"`
+	K8sClient      K8sClient          `mapstructure:"k8sClient"`
+	Logging        Logging            `mapstructure:"logging"`
+	Database       Database           `mapstructure:"database"`
+	Targets        target.Targets     `mapstructure:"target"`
+	SourceConfig   []SourceConfig     `mapstructure:"sourceConfig"`
+	Templates      Templates          `mapstructure:"templates"`
+	CRD            CRD                `mapstructure:"crd"`
+	PeriodicSync   PeriodicSyncConfig `mapstructure:"periodicSync"`
 }

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -565,7 +565,15 @@ func (r *Resolver) PolicyReportClient() (report.PolicyReportClient, error) {
 		return nil, err
 	}
 
-	r.policyReportClient = kubernetes.NewPolicyReportClient(client, r.ReportFilter(), queue)
+	// Get periodic sync settings from config
+	periodicSync := r.config.PeriodicSync.Enabled
+	syncInterval := time.Duration(r.config.PeriodicSync.Interval) * time.Minute
+
+	zap.L().Info("policy report client configuration",
+		zap.Bool("periodicSync", periodicSync),
+		zap.Duration("syncInterval", syncInterval))
+
+	r.policyReportClient = kubernetes.NewPolicyReportClient(client, r.ReportFilter(), queue, periodicSync, syncInterval)
 
 	return r.policyReportClient, nil
 }


### PR DESCRIPTION
Currently, our service relies on incremental updates from Kyverno clusters, which may lead to gaps in report visibility (e.g., due to missed events or transient failures).

I've added an opt-in feature (disabled by default) to periodically sync all available reports from clusters.
It improves reliability of policy violation tracking without disrupting existing workflows and
mitigates risks of silent gaps in reporting.

Please have a look at this PR.