### PR TITLE
add resync all policyreport and clusterpolicy report functionality

### DIFF
--- a/charts/policy-reporter/configs/core.tmpl
+++ b/charts/policy-reporter/configs/core.tmpl
@@ -198,6 +198,11 @@ database:
   secretRef: {{ .Values.database.secretRef }}
   mountedSecret: {{ .Values.database.mountedSecret }}
 
+{{- with .Values.periodicSync }}
+periodicSync:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
 {{- with .Values.extraConfig }}
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -878,6 +878,13 @@ database:
   # supported fields: username, password, host, dsn, database
   mountedSecret: ""
 
+# Add this configuration section for periodic sync
+periodicSync:
+  # Enable periodic sync of policy reports
+  enabled: false
+  # Interval in minutes for periodic sync
+  interval: 30
+
 # enabled if replicaCount > 1
 podDisruptionBudget:
   # -- Configures the minimum available pods for policy-reporter disruptions.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,26 +179,32 @@ type CRD struct {
 	TargetConfig bool `mapstructure:"targetConfig"`
 }
 
+type PeriodicSyncConfig struct {
+	Enabled  bool `mapstructure:"enabled"`
+	Interval int  `mapstructure:"interval"` // in minutes
+}
+
 // Config of the PolicyReporter
 type Config struct {
 	Version        string
-	Namespace      string         `mapstructure:"namespace"`
-	API            API            `mapstructure:"api"`
-	WorkerCount    int            `mapstructure:"worker"`
-	DBFile         string         `mapstructure:"dbfile"`
-	Metrics        Metrics        `mapstructure:"metrics"`
-	REST           REST           `mapstructure:"rest"`
-	ReportFilter   ReportFilter   `mapstructure:"reportFilter"`
-	SourceFilters  []SourceFilter `mapstructure:"sourceFilters"`
-	Redis          Redis          `mapstructure:"redis"`
-	Profiling      Profiling      `mapstructure:"profiling"`
-	EmailReports   EmailReports   `mapstructure:"emailReports"`
-	LeaderElection LeaderElection `mapstructure:"leaderElection"`
-	K8sClient      K8sClient      `mapstructure:"k8sClient"`
-	Logging        Logging        `mapstructure:"logging"`
-	Database       Database       `mapstructure:"database"`
-	Targets        target.Targets `mapstructure:"target"`
-	SourceConfig   []SourceConfig `mapstructure:"sourceConfig"`
-	Templates      Templates      `mapstructure:"templates"`
-	CRD            CRD            `mapstructure:"crd"`
+	Namespace      string             `mapstructure:"namespace"`
+	API            API                `mapstructure:"api"`
+	WorkerCount    int                `mapstructure:"worker"`
+	DBFile         string             `mapstructure:"dbfile"`
+	Metrics        Metrics            `mapstructure:"metrics"`
+	REST           REST               `mapstructure:"rest"`
+	ReportFilter   ReportFilter       `mapstructure:"reportFilter"`
+	SourceFilters  []SourceFilter     `mapstructure:"sourceFilters"`
+	Redis          Redis              `mapstructure:"redis"`
+	Profiling      Profiling          `mapstructure:"profiling"`
+	EmailReports   EmailReports       `mapstructure:"emailReports"`
+	LeaderElection LeaderElection     `mapstructure:"leaderElection"`
+	K8sClient      K8sClient          `mapstructure:"k8sClient"`
+	Logging        Logging            `mapstructure:"logging"`
+	Database       Database           `mapstructure:"database"`
+	Targets        target.Targets     `mapstructure:"target"`
+	SourceConfig   []SourceConfig     `mapstructure:"sourceConfig"`
+	Templates      Templates          `mapstructure:"templates"`
+	CRD            CRD                `mapstructure:"crd"`
+	PeriodicSync   PeriodicSyncConfig `mapstructure:"periodicSync"`
 }

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -692,7 +692,6 @@ func (r *Resolver) WGPolicyReportClient() (report.PolicyReportClient, error) {
 		return nil, err
 	}
 
-	// Get periodic sync settings from config
 	periodicSync := r.config.PeriodicSync.Enabled
 	syncInterval := time.Duration(r.config.PeriodicSync.Interval) * time.Minute
 
@@ -700,7 +699,7 @@ func (r *Resolver) WGPolicyReportClient() (report.PolicyReportClient, error) {
 		zap.Bool("periodicSync", periodicSync),
 		zap.Duration("syncInterval", syncInterval))
 
-	r.wgpolicyClient = wgpolicyclient.NewPolicyReportClient(client, r.ReportFilter(), queue, periodicSync, syncInterval)
+	r.wgpolicyClient = wgpolicyclient.NewPolicyReportClient(client, r.ReportFilter(), queue, periodicSync, syncInterval, r.ResultCache())
 
 	return r.wgpolicyClient, nil
 }
@@ -731,7 +730,14 @@ func (r *Resolver) OpenReportsClient() (report.PolicyReportClient, error) {
 		return nil, err
 	}
 
-	r.openreportsClient = orclient.NewOpenreportsClient(client, r.ReportFilter(), queue)
+	periodicSync := r.config.PeriodicSync.Enabled
+	syncInterval := time.Duration(r.config.PeriodicSync.Interval) * time.Minute
+
+	zap.L().Info("openreports client configuration",
+		zap.Bool("periodicSync", periodicSync),
+		zap.Duration("syncInterval", syncInterval))
+
+	r.openreportsClient = orclient.NewOpenreportsClient(client, r.ReportFilter(), queue, periodicSync, syncInterval, r.ResultCache())
 
 	return r.openreportsClient, nil
 }

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -692,7 +692,15 @@ func (r *Resolver) WGPolicyReportClient() (report.PolicyReportClient, error) {
 		return nil, err
 	}
 
-	r.wgpolicyClient = wgpolicyclient.NewPolicyReportClient(client, r.ReportFilter(), queue)
+	// Get periodic sync settings from config
+	periodicSync := r.config.PeriodicSync.Enabled
+	syncInterval := time.Duration(r.config.PeriodicSync.Interval) * time.Minute
+
+	zap.L().Info("wgpolicy report client configuration",
+		zap.Bool("periodicSync", periodicSync),
+		zap.Duration("syncInterval", syncInterval))
+
+	r.wgpolicyClient = wgpolicyclient.NewPolicyReportClient(client, r.ReportFilter(), queue, periodicSync, syncInterval)
 
 	return r.wgpolicyClient, nil
 }

--- a/pkg/kubernetes/openreports/client.go
+++ b/pkg/kubernetes/openreports/client.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"openreports.io/apis/openreports.io/v1alpha1"
 
+	prcache "github.com/kyverno/policy-reporter/pkg/cache"
 	"github.com/kyverno/policy-reporter/pkg/report"
 )
 
@@ -27,6 +28,9 @@ type openreportsClient struct {
 	mx           *sync.Mutex
 	reportFilter *report.MetaFilter
 	stopChan     chan struct{}
+	periodicSync bool
+	syncInterval time.Duration
+	cache        prcache.Cache
 }
 
 func (k *openreportsClient) HasSynced() bool {
@@ -71,6 +75,32 @@ func (k *openreportsClient) Run(worker int, stopper chan struct{}) error {
 		return err
 	}
 
+	// Periodic sync if enabled - just stop the informer to trigger restart
+	if k.periodicSync {
+		zap.L().Info("openreports periodic sync enabled",
+			zap.String("interval", k.syncInterval.String()))
+		ticker := time.NewTicker(k.syncInterval)
+		go func() {
+			for {
+				select {
+				case <-ticker.C:
+					zap.L().Info("triggering openreports sync - clearing cache and stopping informer")
+					if k.cache != nil {
+						k.cache.Clear()
+						zap.L().Info("result cache cleared for openreports periodic sync")
+					}
+					k.Stop()
+					return
+				case <-stopper:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+	} else {
+		zap.L().Info("openreports periodic sync disabled")
+	}
+
 	k.queue.Run(worker, stopper)
 	return nil
 }
@@ -108,11 +138,14 @@ func (k *openreportsClient) configureInformer(informer cache.SharedIndexInformer
 }
 
 // NewPolicyReportClient new Client for Policy Report Kubernetes API
-func NewOpenreportsClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *ORQueue) report.PolicyReportClient {
+func NewOpenreportsClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *ORQueue, periodicSync bool, syncInterval time.Duration, cache prcache.Cache) report.PolicyReportClient {
 	return &openreportsClient{
 		metaClient:   metaClient,
 		mx:           &sync.Mutex{},
 		queue:        queue,
 		reportFilter: reportFilter,
+		periodicSync: periodicSync,
+		syncInterval: syncInterval,
+		cache:        cache,
 	}
 }

--- a/pkg/kubernetes/openreports/policy_report_client_test.go
+++ b/pkg/kubernetes/openreports/policy_report_client_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/kyverno/policy-reporter/pkg/cache"
 	"github.com/kyverno/policy-reporter/pkg/fixtures"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes"
 	"github.com/kyverno/policy-reporter/pkg/report"
@@ -45,7 +46,7 @@ func Test_PolicyReportWatcher(t *testing.T) {
 	)
 
 	kclient, rclient, _ := NewFakeMetaClient()
-	client := NewOpenreportsClient(kclient, filter, queue)
+	client := NewOpenreportsClient(kclient, filter, queue, false, 0, cache.NewInMermoryCache(time.Hour, time.Minute))
 
 	go func() {
 		err := client.Run(1, stop)
@@ -98,7 +99,7 @@ func Test_ClusterPolicyReportWatcher(t *testing.T) {
 	)
 
 	kclient, _, rclient := NewFakeMetaClient()
-	client := NewOpenreportsClient(kclient, filter, queue)
+	client := NewOpenreportsClient(kclient, filter, queue, false, 0, cache.NewInMermoryCache(time.Hour, time.Minute))
 
 	go func() {
 		err := client.Run(1, stop)
@@ -140,7 +141,7 @@ func Test_HasSynced(t *testing.T) {
 	)
 
 	kclient, _, _ := NewFakeMetaClient()
-	client := NewOpenreportsClient(kclient, filter, queue)
+	client := NewOpenreportsClient(kclient, filter, queue, false, 0, cache.NewInMermoryCache(time.Hour, time.Minute))
 
 	err := client.Sync(stop)
 	if err != nil {

--- a/pkg/kubernetes/wgpolicy/client.go
+++ b/pkg/kubernetes/wgpolicy/client.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/tools/cache"
 
+	prcache "github.com/kyverno/policy-reporter/pkg/cache"
 	pr "github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
 	"github.com/kyverno/policy-reporter/pkg/report"
 )
@@ -21,16 +22,15 @@ var (
 )
 
 type wgpolicyReportClient struct {
-	queue         *WGPolicyQueue
-	metaClient    metadata.Interface
-	synced        bool
-	mx            *sync.Mutex
-	reportFilter  *report.MetaFilter
-	stopChan      chan struct{}
-	polrInformer  cache.SharedIndexInformer
-	cpolrInformer cache.SharedIndexInformer
-	periodicSync  bool
-	syncInterval  time.Duration
+	queue        *WGPolicyQueue
+	metaClient   metadata.Interface
+	synced       bool
+	mx           *sync.Mutex
+	reportFilter *report.MetaFilter
+	stopChan     chan struct{}
+	periodicSync bool
+	syncInterval time.Duration
+	cache        prcache.Cache
 }
 
 func (k *wgpolicyReportClient) HasSynced() bool {
@@ -44,19 +44,21 @@ func (k *wgpolicyReportClient) Stop() {
 func (k *wgpolicyReportClient) Sync(stopper chan struct{}) error {
 	factory := metadatainformer.NewSharedInformerFactory(k.metaClient, 15*time.Minute)
 
-	k.polrInformer = k.configureInformer(factory.ForResource(PolrResource).Informer())
+	var cpolrInformer cache.SharedIndexInformer
+
+	polrInformer := k.configureInformer(factory.ForResource(PolrResource).Informer())
 
 	if !k.reportFilter.DisableClusterReports() {
-		k.cpolrInformer = k.configureInformer(factory.ForResource(CpolrResource).Informer())
+		cpolrInformer = k.configureInformer(factory.ForResource(CpolrResource).Informer())
 	}
 
 	factory.Start(stopper)
 
-	if !cache.WaitForCacheSync(stopper, k.polrInformer.HasSynced) {
+	if !cache.WaitForCacheSync(stopper, polrInformer.HasSynced) {
 		return fmt.Errorf("failed to sync policy reports")
 	}
 
-	if k.cpolrInformer != nil && !cache.WaitForCacheSync(stopper, k.cpolrInformer.HasSynced) {
+	if cpolrInformer != nil && !cache.WaitForCacheSync(stopper, cpolrInformer.HasSynced) {
 		return fmt.Errorf("failed to sync cluster policy reports")
 	}
 
@@ -73,10 +75,7 @@ func (k *wgpolicyReportClient) Run(worker int, stopper chan struct{}) error {
 		return err
 	}
 
-	// Initial sync of existing reports
-	go k.syncExistingReports()
-
-	// Periodic sync if enabled
+	// Periodic sync if enabled - just stop the informer to trigger restart
 	if k.periodicSync {
 		zap.L().Info("policy report periodic sync enabled",
 			zap.String("interval", k.syncInterval.String()))
@@ -85,7 +84,13 @@ func (k *wgpolicyReportClient) Run(worker int, stopper chan struct{}) error {
 			for {
 				select {
 				case <-ticker.C:
-					k.syncExistingReports()
+					zap.L().Info("triggering policy report sync - clearing cache and stopping informer")
+					if k.cache != nil {
+						k.cache.Clear()
+						zap.L().Info("result cache cleared for periodic sync")
+					}
+					k.Stop()
+					return
 				case <-stopper:
 					ticker.Stop()
 					return
@@ -98,36 +103,6 @@ func (k *wgpolicyReportClient) Run(worker int, stopper chan struct{}) error {
 
 	k.queue.Run(worker, stopper)
 	return nil
-}
-
-func (k *wgpolicyReportClient) syncExistingReports() {
-	total := 0
-
-	if k.polrInformer != nil {
-		items := k.polrInformer.GetStore().List()
-		for _, item := range items {
-			if meta, ok := item.(*v1.PartialObjectMetadata); ok {
-				if k.reportFilter.AllowReport(meta) {
-					k.queue.Add(meta)
-					total++
-				}
-			}
-		}
-	}
-
-	if k.cpolrInformer != nil {
-		items := k.cpolrInformer.GetStore().List()
-		for _, item := range items {
-			if meta, ok := item.(*v1.PartialObjectMetadata); ok {
-				if k.reportFilter.AllowReport(meta) {
-					k.queue.Add(meta)
-					total++
-				}
-			}
-		}
-	}
-
-	zap.L().Info("syncing existing policy reports", zap.Int("count", total))
 }
 
 func (k *wgpolicyReportClient) configureInformer(informer cache.SharedIndexInformer) cache.SharedIndexInformer {
@@ -163,15 +138,14 @@ func (k *wgpolicyReportClient) configureInformer(informer cache.SharedIndexInfor
 }
 
 // NewPolicyReportClient new Client for Policy Report Kubernetes API
-func NewPolicyReportClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *WGPolicyQueue, periodicSync bool, syncInterval time.Duration) report.PolicyReportClient {
+func NewPolicyReportClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *WGPolicyQueue, periodicSync bool, syncInterval time.Duration, cache prcache.Cache) report.PolicyReportClient {
 	return &wgpolicyReportClient{
-		metaClient:    metaClient,
-		mx:            &sync.Mutex{},
-		queue:         queue,
-		reportFilter:  reportFilter,
-		polrInformer:  nil,
-		cpolrInformer: nil,
-		periodicSync:  periodicSync,
-		syncInterval:  syncInterval,
+		metaClient:   metaClient,
+		mx:           &sync.Mutex{},
+		queue:        queue,
+		reportFilter: reportFilter,
+		periodicSync: periodicSync,
+		syncInterval: syncInterval,
+		cache:        cache,
 	}
 }

--- a/pkg/kubernetes/wgpolicy/client.go
+++ b/pkg/kubernetes/wgpolicy/client.go
@@ -21,12 +21,16 @@ var (
 )
 
 type wgpolicyReportClient struct {
-	queue        *WGPolicyQueue
-	metaClient   metadata.Interface
-	synced       bool
-	mx           *sync.Mutex
-	reportFilter *report.MetaFilter
-	stopChan     chan struct{}
+	queue         *WGPolicyQueue
+	metaClient    metadata.Interface
+	synced        bool
+	mx            *sync.Mutex
+	reportFilter  *report.MetaFilter
+	stopChan      chan struct{}
+	polrInformer  cache.SharedIndexInformer
+	cpolrInformer cache.SharedIndexInformer
+	periodicSync  bool
+	syncInterval  time.Duration
 }
 
 func (k *wgpolicyReportClient) HasSynced() bool {
@@ -40,21 +44,19 @@ func (k *wgpolicyReportClient) Stop() {
 func (k *wgpolicyReportClient) Sync(stopper chan struct{}) error {
 	factory := metadatainformer.NewSharedInformerFactory(k.metaClient, 15*time.Minute)
 
-	var cpolrInformer cache.SharedIndexInformer
-
-	polrInformer := k.configureInformer(factory.ForResource(PolrResource).Informer())
+	k.polrInformer = k.configureInformer(factory.ForResource(PolrResource).Informer())
 
 	if !k.reportFilter.DisableClusterReports() {
-		cpolrInformer = k.configureInformer(factory.ForResource(PolrResource).Informer())
+		k.cpolrInformer = k.configureInformer(factory.ForResource(CpolrResource).Informer())
 	}
 
 	factory.Start(stopper)
 
-	if !cache.WaitForCacheSync(stopper, polrInformer.HasSynced) {
+	if !cache.WaitForCacheSync(stopper, k.polrInformer.HasSynced) {
 		return fmt.Errorf("failed to sync policy reports")
 	}
 
-	if cpolrInformer != nil && !cache.WaitForCacheSync(stopper, cpolrInformer.HasSynced) {
+	if k.cpolrInformer != nil && !cache.WaitForCacheSync(stopper, k.cpolrInformer.HasSynced) {
 		return fmt.Errorf("failed to sync cluster policy reports")
 	}
 
@@ -71,8 +73,61 @@ func (k *wgpolicyReportClient) Run(worker int, stopper chan struct{}) error {
 		return err
 	}
 
+	// Initial sync of existing reports
+	go k.syncExistingReports()
+
+	// Periodic sync if enabled
+	if k.periodicSync {
+		zap.L().Info("policy report periodic sync enabled",
+			zap.String("interval", k.syncInterval.String()))
+		ticker := time.NewTicker(k.syncInterval)
+		go func() {
+			for {
+				select {
+				case <-ticker.C:
+					k.syncExistingReports()
+				case <-stopper:
+					ticker.Stop()
+					return
+				}
+			}
+		}()
+	} else {
+		zap.L().Info("policy report periodic sync disabled")
+	}
+
 	k.queue.Run(worker, stopper)
 	return nil
+}
+
+func (k *wgpolicyReportClient) syncExistingReports() {
+	total := 0
+
+	if k.polrInformer != nil {
+		items := k.polrInformer.GetStore().List()
+		for _, item := range items {
+			if meta, ok := item.(*v1.PartialObjectMetadata); ok {
+				if k.reportFilter.AllowReport(meta) {
+					k.queue.Add(meta)
+					total++
+				}
+			}
+		}
+	}
+
+	if k.cpolrInformer != nil {
+		items := k.cpolrInformer.GetStore().List()
+		for _, item := range items {
+			if meta, ok := item.(*v1.PartialObjectMetadata); ok {
+				if k.reportFilter.AllowReport(meta) {
+					k.queue.Add(meta)
+					total++
+				}
+			}
+		}
+	}
+
+	zap.L().Info("syncing existing policy reports", zap.Int("count", total))
 }
 
 func (k *wgpolicyReportClient) configureInformer(informer cache.SharedIndexInformer) cache.SharedIndexInformer {
@@ -108,11 +163,15 @@ func (k *wgpolicyReportClient) configureInformer(informer cache.SharedIndexInfor
 }
 
 // NewPolicyReportClient new Client for Policy Report Kubernetes API
-func NewPolicyReportClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *WGPolicyQueue) report.PolicyReportClient {
+func NewPolicyReportClient(metaClient metadata.Interface, reportFilter *report.MetaFilter, queue *WGPolicyQueue, periodicSync bool, syncInterval time.Duration) report.PolicyReportClient {
 	return &wgpolicyReportClient{
-		metaClient:   metaClient,
-		mx:           &sync.Mutex{},
-		queue:        queue,
-		reportFilter: reportFilter,
+		metaClient:    metaClient,
+		mx:            &sync.Mutex{},
+		queue:         queue,
+		reportFilter:  reportFilter,
+		polrInformer:  nil,
+		cpolrInformer: nil,
+		periodicSync:  periodicSync,
+		syncInterval:  syncInterval,
 	}
 }

--- a/pkg/target/http/utils.go
+++ b/pkg/target/http/utils.go
@@ -47,7 +47,7 @@ func ProcessHTTPResponse(target string, resp *http.Response, err error) {
 
 		zap.L().Error(target+": PUSH FAILED", zap.Error(err), zap.String("body", buf.String()), zap.Int("statusCode", resp.StatusCode))
 	} else if err != nil {
-		zap.L().Error(target+": PUSH FAILED", zap.Int("statusCode", resp.StatusCode))
+		zap.L().Error(target+": PUSH FAILED", zap.Error(err))
 	} else if resp.StatusCode >= 400 {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(resp.Body)


### PR DESCRIPTION
Currently, our service relies on incremental updates of policyreports from Kyverno clusters, which may lead to gaps in report visibility (e.g., due to missed events or transient failures).

I've added an opt-in feature (disabled by default) to periodically sync all available reports from clusters.
It improves reliability of policy violation tracking without disrupting existing workflows and
mitigates risks of silent gaps in reporting.

Please have a look at this PR.