### PR TITLE
fix(chart): ui: networkpolicy: avoid pulling egress rules from policy-reporter networkpolicy

### DIFF
--- a/charts/policy-reporter/templates/ui/networkpolicy.yaml
+++ b/charts/policy-reporter/templates/ui/networkpolicy.yaml
@@ -46,7 +46,7 @@ spec:
     - protocol: TCP
       port: {{ .Values.plugin.trivy.service.port }}
   {{- end }}
-  {{- with .Values.networkPolicy.egress }}
+  {{- with .Values.ui.networkPolicy.egress }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The values reflect the appropriate structure: https://github.com/kyverno/policy-reporter/blob/80ec5b899cc99a355762809d4dbbbe5c1e1be292/charts/policy-reporter/values.yaml#L1231-L1236

However, the `policy-reporter-ui`'s `NetworkPolicy` template, specifically for egress rules, refers to `.Values.networkPolicy.egress` rather than the expected `.Values.ui.networkPolicy.egress`. This patch simply fixes the template