### PR TITLE
fix(dashboard): Errored Resources uses expression with status warn

### DIFF
--- a/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/clusterpolicy-details.dashboard.yaml
@@ -720,7 +720,7 @@ data:
         "pluginVersion": "7.1.5",
         "targets": [
             {
-            "expr": "max(sum(cluster_policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", status=\"warn\"{{ range $filters }}, {{.}}=~\"${{.}}\"{{ end }} }) by (pod, policy,rule,kind,name,status,severity,category,source{{ range $filters }},{{.}}{{ end }})) by (policy,rule,kind,name,status,severity,category,source{{ range $filters }},{{.}}{{ end }})",
+            "expr": "max(sum(cluster_policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", status=\"error\"{{ range $filters }}, {{.}}=~\"${{.}}\"{{ end }} }) by (pod, policy,rule,kind,name,status,severity,category,source{{ range $filters }},{{.}}{{ end }})) by (policy,rule,kind,name,status,severity,category,source{{ range $filters }},{{.}}{{ end }})",
             "format": "table",
             "instant": true,
             "interval": "",


### PR DESCRIPTION
Currently the Panel **Errored Resources** shows `cluster_policy_report_result` with `status` **warn** instead of **error**.